### PR TITLE
Fix build issues on Ubuntu 16.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 message(STATUS "CMake version: " ${CMAKE_VERSION})
 
 # Set to the current lowest tested version of CMake
-cmake_minimum_required (VERSION 3.7.0 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.5.0 FATAL_ERROR)
 
 project (EnvironmentSimulator)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 message(STATUS "CMake version: " ${CMAKE_VERSION})
 
 # Set to the current lowest tested version of CMake
-cmake_minimum_required (VERSION 3.5.0 FATAL_ERROR)
+#if(WIN32)
+  # for cmake generator VisualStudio 2017 support
+  cmake_minimum_required (VERSION 3.7.0 FATAL_ERROR)
+#else
+  cmake_minimum_required (VERSION 3.5.0 FATAL_ERROR)
+#endif()
 
 project (EnvironmentSimulator)
 

--- a/EnvironmentSimulator/CMakeLists.txt
+++ b/EnvironmentSimulator/CMakeLists.txt
@@ -38,7 +38,7 @@ set ( OSG_INCLUDE_DIR
 )
 set ( OSG_LIBRARIES_PATH 
 	"${OSG_DIR}/lib" 
-	"${OSG_DIR}/lib/osgPlugins-3.7.0"
+	"${OSG_DIR}/lib/osgPlugins-3.6.3"
 )
 
 if(UNIX)
@@ -52,6 +52,8 @@ if(UNIX)
 
   add_library( db_osg UNKNOWN IMPORTED)
   set_property(TARGET db_osg PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/../externals/OpenSceneGraph/v10/lib/osgPlugins-3.6.3/osgdb_osg.so")
+
+  link_directories(${OSG_LIBRARIES_PATH})
 
   set ( OSG_LIBRARIES
 	GL
@@ -72,7 +74,7 @@ if(UNIX)
 	db_serializers_osgsim
 	db_serializers_osg
 	db_osg
-	db_fbx
+	#db_fbx
   )
 else() #not UNIX
 

--- a/EnvironmentSimulator/CMakeLists.txt
+++ b/EnvironmentSimulator/CMakeLists.txt
@@ -38,7 +38,11 @@ set ( OSG_INCLUDE_DIR
 )
 set ( OSG_LIBRARIES_PATH 
 	"${OSG_DIR}/lib" 
+#if(WIN32)
+	"${OSG_DIR}/lib/osgPlugins-3.7.0"
+#else
 	"${OSG_DIR}/lib/osgPlugins-3.6.3"
+#endif
 )
 
 if(UNIX)


### PR DESCRIPTION
This PR fixes several build issues experienced on Ubuntu 16.04

* The required cmake version is downgraded from 3.7 to 3.5, as 3.7 seems not required and 3.5 is the default in Ubuntu 16.04 (which is supported according to the documentation)
* Linking of the OpenSceneGraph libraries did not work completely, so the linking flags were updated