### PR TITLE
[qroadmngr] Fixed an issue where Position::XYZH2TrackPos would return…

### DIFF
--- a/EnvironmentSimulator/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/RoadManager/RoadManager.cpp
@@ -2929,8 +2929,8 @@ void Position::XYZH2TrackPos(double x3, double y3, double z3, double h3, bool al
 	geomMin->EvaluateDS(dsMin, &x, &y, &h_road_);
 	
 	// Apply lane offset
-	x += roadMin->GetLaneOffset(dsMin) * cos(h_road_ + M_PI_2);
-	y += roadMin->GetLaneOffset(dsMin) * sin(h_road_ + M_PI_2);
+	x += roadMin->GetLaneOffset(sMin) * cos(h_road_ + M_PI_2);
+	y += roadMin->GetLaneOffset(sMin) * sin(h_road_ + M_PI_2);
 	distMin = PointDistance2D(x3, y3, x, y);
 
 	// Check whether the point is left or right side of road


### PR DESCRIPTION
Hi,

After I pushed #18, I continued with my tests on my OpenDRIVE file, and the road just after the one that lead me to #18 also lead to a new issue! But this was way easier to solve.

It turns out that ```Position::XYZH2TrackPos``` uses the wrong S-coordinate when it calls ```Road::GetLaneOffset``` (local geometry S instead of local road S). This lead to a wrong T coordinate, then a wrong lane.