### PR TITLE
[roadmngr] Fixed an issue where Delta would return wrong distance on …

### DIFF
--- a/EnvironmentSimulator/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/RoadManager/RoadManager.cpp
@@ -2715,8 +2715,15 @@ int RoadPath::Calculate(double &dist)
 
 				if (nextRoad == targetRoad)
 				{
-					// Special case: On same road, distance is equal to delta s
-					tmpDist += targetPos_->GetS();
+					// Special case: On same road, distance is equal to delta s, direction considered
+					if (nextRoad->GetLink(LinkType::PREDECESSOR)->GetElementId() == pivotRoad->GetId())
+					{
+						tmpDist += targetPos_->GetS();
+					}
+					else
+					{
+						tmpDist += nextRoad->GetLength() - targetPos_->GetS();
+					}
 					found = true;
 				}
 				else


### PR DESCRIPTION
Hi Emil,

I came across an issue in the new `Position::Delta()` algorithm. When the final bit of distance is added to the buffer (`tmpDist`), if the target road is within a junction, the direction isn't considered (https://github.com/esmini/esmini/blob/master/EnvironmentSimulator/RoadManager/RoadManager.cpp#L2719). This means that depending on the road direction, the returned value could be wrong.

That's not the case if the target road isn't within a junction, where direction is indeed considered (https://github.com/esmini/esmini/blob/master/EnvironmentSimulator/RoadManager/RoadManager.cpp#L2688-L2695).

This commit should fix this issue (it did on my tests at least).

Thanks for all your work, it's greatly appreciated!

Bertrand