### PR TITLE
Add data to OSI orientationRate.yaw

### DIFF
--- a/EnvironmentSimulator/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/RoadManager/RoadManager.cpp
@@ -3341,6 +3341,7 @@ void Position::Init()
 	accX_ = 0.0;
 	accY_ = 0.0;
 	accZ_ = 0.0;
+	rateH_ = 0.0;
 	h_offset_ = 0.0;
 	h_road_ = 0.0;
 	h_relative_ = 0.0;

--- a/EnvironmentSimulator/RoadManager/RoadManager.hpp
+++ b/EnvironmentSimulator/RoadManager/RoadManager.hpp
@@ -1324,6 +1324,7 @@ namespace roadmanager
 		void SetY(double y) { y_ = y; }
 		void SetZ(double z) { z_ = z; }
 		void SetH(double h) { h_ = h; }
+		void SetHRate(double h) { rateH_ = h; }
 		void SetP(double p) { p_ = p; }
 		void SetR(double r) { r_ = r; }
 		void SetVelX(double x) { velX_ = x; }
@@ -1338,6 +1339,7 @@ namespace roadmanager
 		double GetAccX() { return accX_; }
 		double GetAccY() { return accY_; }
 		double GetAccZ() { return accZ_; }
+		double GetHRate() { return rateH_; }
 
 		void SetOrientationType(OrientationType type) { orientation_type_ = type; }
 
@@ -1391,6 +1393,7 @@ namespace roadmanager
 		double	y_;
 		double	z_;
 		double	h_;
+		double  rateH_;
 		double	p_;
 		double	r_;
 		double	velX_;

--- a/EnvironmentSimulator/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
+++ b/EnvironmentSimulator/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
@@ -503,7 +503,7 @@ void ScenarioEngine::stepObjects(double dt)
 				obj->pos_.SetVelY((obj->pos_.GetY() - pos_y_old) / dt);
 				obj->pos_.SetAccX((obj->pos_.GetVelX() - vel_x_old) / dt);
 				obj->pos_.SetAccY((obj->pos_.GetVelY() - vel_y_old) / dt);
-				obj->pos_.SetHRate((obj->pos_.GetH() - heading_old) / dt);
+				obj->pos_.SetHRate(GetAngleDifference(obj->pos_.GetH(), heading_old) / dt);
 			}
 		}
 		obj->trail_.AddState((float)simulationTime, (float)obj->pos_.GetX(), (float)obj->pos_.GetY(), (float)obj->pos_.GetZ(), (float)obj->speed_);

--- a/EnvironmentSimulator/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
+++ b/EnvironmentSimulator/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
@@ -471,6 +471,7 @@ void ScenarioEngine::stepObjects(double dt)
 			double pos_y_old = obj->pos_.GetY();
 			double vel_x_old = obj->pos_.GetVelX();
 			double vel_y_old = obj->pos_.GetVelY();
+			double heading_old = obj->pos_.GetH();
 
 			double steplen = obj->speed_ * dt;
 
@@ -495,13 +496,14 @@ void ScenarioEngine::stepObjects(double dt)
 			}
 			obj->odometer_ += abs(steplen);  // odometer always measure all movements as positive, I guess...
 
-			// Calculate resulting updated velocity and acceleration NOTE: in global coordinate sys
+			// Calculate resulting updated velocity, acceleration and heading rate (rad/s) NOTE: in global coordinate sys
 			if (dt > SMALL_NUMBER)
 			{
 				obj->pos_.SetVelX((obj->pos_.GetX() - pos_x_old) / dt);
 				obj->pos_.SetVelY((obj->pos_.GetY() - pos_y_old) / dt);
 				obj->pos_.SetAccX((obj->pos_.GetVelX() - vel_x_old) / dt);
 				obj->pos_.SetAccY((obj->pos_.GetVelY() - vel_y_old) / dt);
+				obj->pos_.SetHRate((obj->pos_.GetH() - heading_old) / dt);
 			}
 		}
 		obj->trail_.AddState((float)simulationTime, (float)obj->pos_.GetX(), (float)obj->pos_.GetY(), (float)obj->pos_.GetZ(), (float)obj->speed_);

--- a/EnvironmentSimulator/ScenarioEngine/SourceFiles/ScenarioGateway.cpp
+++ b/EnvironmentSimulator/ScenarioEngine/SourceFiles/ScenarioGateway.cpp
@@ -345,6 +345,7 @@ int ScenarioGateway::UpdateOSIMovingObject()
 		mobj_osi_internal.mobj[i]->mutable_base()->mutable_position()->set_y(objectState_[i]->state_.pos.GetY());
 		mobj_osi_internal.mobj[i]->mutable_base()->mutable_position()->set_z(objectState_[i]->state_.pos.GetZ());
 		mobj_osi_internal.mobj[i]->mutable_base()->mutable_orientation()->set_yaw(objectState_[i]->state_.pos.GetH());
+		mobj_osi_internal.mobj[i]->mutable_base()->mutable_orientation_rate()->set_yaw(objectState_[i]->state_.pos.GetHRate());
 		mobj_osi_internal.mobj[i]->mutable_base()->mutable_orientation()->set_pitch(objectState_[i]->state_.pos.GetP());
 		mobj_osi_internal.mobj[i]->mutable_base()->mutable_orientation()->set_roll(objectState_[i]->state_.pos.GetR());
 		mobj_osi_internal.mobj[i]->mutable_base()->mutable_velocity()->set_x(objectState_[i]->state_.pos.GetVelX());


### PR DESCRIPTION
By using previous heading and the new heading
the orientation rate is calculated.
The orientation rate is set after the MoveAlongS function
which steps each object forward so we are sure
we are getting the new heading.
The heading rate is found in the position object along
with similar data, such as heading and velocity.