### PR TITLE
Fixed bugs in Position::GetDistToTrackGeom

### DIFF
--- a/EnvironmentSimulator/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/RoadManager/RoadManager.cpp
@@ -5360,11 +5360,10 @@ int Position::MoveAlongS(double ds, double dLaneOffset, Junction::JunctionStrate
 	// the SIGN() adjustment. But for now this adjustment means that a positive dLaneOffset always moves left?
 	offset_ += dLaneOffset * -SIGN(GetLaneId());
 	double s_stop = 0;
+	ds_signed = -SIGN(GetLaneId()) * ds; // adjust sign of ds according to lane direction - right lane is < 0 in road dir
 	
 	for (int i = 0; i < max_links; i++)
 	{
-		ds_signed = -SIGN(GetLaneId()) * ds; // adjust sign of ds according to lane direction - right lane is < 0 in road dir
-
 		if (s_ + ds_signed > GetOpenDrive()->GetRoadByIdx(track_idx_)->GetLength())
 		{
 			ds_signed = s_ + ds_signed - GetOpenDrive()->GetRoadByIdx(track_idx_)->GetLength();
@@ -5390,7 +5389,12 @@ int Position::MoveAlongS(double ds, double dLaneOffset, Junction::JunctionStrate
 			return ErrorCode::ERROR_END_OF_ROAD;
 		}
 
-		ds = SIGN(ds) * fabs(ds_signed);
+		// Roads aren't going the same direction, we flip ds
+		if ((link->GetType() == LinkType::PREDECESSOR && contact_point_type == ContactPointType::CONTACT_POINT_START) ||
+		    (link->GetType() == LinkType::SUCCESSOR && contact_point_type == ContactPointType::CONTACT_POINT_END))
+		{
+			ds_signed *= -1;
+		}
 	}
 
 	SetLanePos(track_id_, lane_id_, s_ + ds_signed, offset_);

--- a/EnvironmentSimulator/RoadManager/RoadManager.hpp
+++ b/EnvironmentSimulator/RoadManager/RoadManager.hpp
@@ -590,7 +590,7 @@ namespace roadmanager
 		double GetS() { return s_; }
 		Lane* GetLaneByIdx(int idx);
 		Lane* GetLaneById(int id);
-		int FindClosestDrivingLane(int id);
+		int FindClosestSnappingLane(int id, Lane::LaneType laneType = Lane::LaneType::LANE_TYPE_ANY_DRIVING);
 		int GetLaneIdByIdx(int idx);
 		int GetLaneIdxById(int id);
 		int GetLaneGlobalIdByIdx(int idx);
@@ -804,7 +804,7 @@ namespace roadmanager
 		*/
 		double GetCenterOffset(double s, int lane_id);
 
-		LaneInfo GetLaneInfoByS(double s, int start_lane_link_idx, int start_lane_id);
+		LaneInfo GetLaneInfoByS(double s, int start_lane_link_idx, int start_lane_id, Lane::LaneType laneType = Lane::LaneType::LANE_TYPE_ANY_DRIVING);
 		double GetLaneWidthByS(double s, int lane_id);
 		double GetSpeedByS(double s);
 		bool GetZAndPitchByS(double s, double *z, double *pitch, int *index);


### PR DESCRIPTION
Hi Emil,

I've encountered a few bugs in Position::GetDistToTrackGeom, so here's a PR. First I'll explain the changes, then I'll go over the example that lead me to those bugs.

The first fix is similar to #19, where the lane offset is wrongly computed from road start instead of geometry start.

The second fix is a bit more complicated, and I'm not entierly satisfied with it, nor have  I thoroughly tested it. The thing is that for points outside the geom, the "exact distance" is still computed, even though there is a comment saying it is not (https://github.com/brifsttar/esmini/blob/e453b9b96980fbb5442399a5e1d3336f5accef02/EnvironmentSimulator/RoadManager/RoadManager.cpp#L4490). This leads to all kinds of weird things happening (more on that in the example).

The third fix is that the method only tries to compute distances on "driving" lanes, which seems a bit arbitrary (and definitely causes me issues, as I'm working with sidewalks).

So my problem was that I tried to map a point to track coordinate using roadmanager::Position. The point is on the sidewalk of the road first geom. But due to the road configuration, the sidewalk is pretty far from the closest driving lane. Since the method only tried to match on driving lanes, the minimal distance found on that geometry was pretty high (~7m).

Then it evaluated the second geometry. It correctly found the point not ```inside```, at a ~6m distance. But that distance is not the lateral (i.e. T) distance, but the distance between the reference point, and the start of the geometry. Which, as it happens in my example, is mostly longitudinal (i.e. S). However, the rest of the algorithm expects ```dist``` to be the lateral distance.

So then, even though the point is outside and dist is NOT lateral distance, it tries to match that ```dist``` onto lanes. And in my case, I have a (driving) lane at a lateral offset of ~7m, so the algorithm sets the ```min_lane_dist``` at 7 (lane offset) - 6 (point offset) = ~1m within the driving lane. When the point actually is on a sidewalk, ~6m behind (longitudinal).

This leads to this value (~1m) being returned to ```XYZH2TrackPos```, where even with the added weight due to being outside (2), this ```dist``` is still lower than the one from the previous (correct) geometry, since this one was computed with driving lane only (and we're on a very wide sidewalk).

I'm pretty confident that I lost you in my explanation, so I also used all of my mspaint skills to draw something (position of geom/points is not accurate).

![](https://i.imgur.com/jMnVR46.png)

The yellow line seperates the two geoms. The green dot is the point I try to get track coordinate. The blue line is the ```dist``` used by the method to match on the first geom, and the orange line is for the second geom. Since the orange is shorter than the blue, it wrongly positions me on the second geom, which leads to all kind of issues.

Below is the coordinate for the green point, and the road description.

If you want a live explanation of all that, it's possible :-)

```
x : 188,20 y : 96,900 z : 108,0
```

```xml
    <road name="Road 161" length="4.3844816182604788e+1" id="161" junction="-1">
        <link>
            <predecessor elementType="junction" elementId="2049"/>
            <successor elementType="junction" elementId="189"/>
        </link>
        <type s="0.0000000000000000e+0" type="town">
            <speed max="50" unit="km/h"/>
        </type>
        <planView>
            <geometry s="0.0000000000000000e+0" x="-2.0418483954313496e+2" y="9.4849797419553639e+1" hdg="3.7632493637335163e-1" length="2.6758439213118052e+1">
                <line/>
            </geometry>
            <geometry s="2.6758439213118052e+1" x="-1.7929891529954256e+2" y="1.0468365951256234e+2" hdg="3.7632493637335163e-1" length="2.3201874848681747e+0">
                <arc curvature="2.0000000000000000e-3"/>
            </geometry>
            <geometry s="2.9078626697986223e+1" x="-1.7714307713347304e+2" y="1.0554134366584879e+2" hdg="3.8096531134313882e-1" length="1.4766189484618565e+1">
                <line/>
            </geometry>
        </planView>
        <elevationProfile>
            <elevation s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
            <elevation s="3.7401783502158139e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
            <elevation s="3.3740178350215814e+1" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
        </elevationProfile>
        <lateralProfile>
            <superelevation s="0.0000000000000000e+0" a="0.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
        </lateralProfile>
        <lanes>
            <laneOffset s="0.0000000000000000e+0" a="-5.0350000000000001e+0" b="1.5067848297979789e-18" c="-1.1178614589718686e-19" d="1.7657692776074944e-21"/>
            <laneSection s="0.0000000000000000e+0" singleSide="false">
                <left>
                    <lane id="7" type="sidewalk" level="false">
                        <width sOffset="0.0000000000000000e+0" a="2.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
                        <speed sOffset="0.0000000000000000e+0" max="5.0000000000000000e+1" unit="km/h"/>
                        <userData>
                            <vectorLane sOffset="0.0000000000000000e+0" laneId="{26a21073-b2e2-4385-9497-9a7701956839}" travelDir="undirected"/>
                        </userData>
                    </lane>
                    <lane id="6" type="shoulder" level="false">
                        <width sOffset="0.0000000000000000e+0" a="6.3499999999999979e-1" b="-1.3456990696216876e-18" c="-6.6080917439023062e-20" d="8.8996486619208633e-22"/>
                        <roadMark sOffset="0.0000000000000000e+0" type="curb" material="standard" width="1.5239999999999998e-1" laneChange="none"/>
                        <speed sOffset="0.0000000000000000e+0" max="5.0000000000000000e+1" unit="km/h"/>
                        <userData>
                            <vectorLane sOffset="0.0000000000000000e+0" laneId="{0899fc78-7e7c-4d96-9247-1f4fd558d920}" travelDir="undirected"/>
                        </userData>
                    </lane>
                    <lane id="5" type="shoulder" level="false">
                        <width sOffset="0.0000000000000000e+0" a="5.0000000000000000e-1" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
                        <speed sOffset="0.0000000000000000e+0" max="5.0000000000000000e+1" unit="km/h"/>
                        <userData>
                            <vectorLane sOffset="0.0000000000000000e+0" laneId="{f22d9c9f-4fbd-4cca-84cb-2f5a66d57945}" travelDir="undirected"/>
                        </userData>
                    </lane>
                    <lane id="4" type="driving" level="false">
                        <width sOffset="0.0000000000000000e+0" a="3.5000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
                        <speed sOffset="0.0000000000000000e+0" max="5.0000000000000000e+1" unit="km/h"/>
                        <userData>
                            <vectorLane sOffset="0.0000000000000000e+0" laneId="{9613e0d4-181a-4261-ad14-2c7d5b5e8e9b}" travelDir="backward"/>
                        </userData>
                    </lane>
                    <lane id="3" type="parking" level="false">
                        <width sOffset="0.0000000000000000e+0" a="2.3999999999999999e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
                        <speed sOffset="0.0000000000000000e+0" max="5.0000000000000000e+1" unit="km/h"/>
                        <userData>
                            <vectorLane sOffset="0.0000000000000000e+0" laneId="{d340caf0-b8db-4265-8f80-7f53a3f79ecc}" travelDir="undirected"/>
                        </userData>
                    </lane>
                    <lane id="2" type="shoulder" level="false">
                        <width sOffset="0.0000000000000000e+0" a="6.3500000000000023e-1" b="-1.5067848297979789e-18" c="-5.7687296792709616e-20" d="7.8232106215609829e-22"/>
                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
                        <speed sOffset="0.0000000000000000e+0" max="5.0000000000000000e+1" unit="km/h"/>
                        <userData>
                            <vectorLane sOffset="0.0000000000000000e+0" laneId="{8798b09e-ac77-4c03-ade3-28b8856c391f}" travelDir="undirected"/>
                        </userData>
                    </lane>
                    <lane id="1" type="sidewalk" level="false">
                        <width sOffset="0.0000000000000000e+0" a="2.0000000000000000e+0" b="0.0000000000000000e+0" c="0.0000000000000000e+0" d="0.0000000000000000e+0"/>
                        <roadMark sOffset="0.0000000000000000e+0" type="curb" material="standard" width="1.5239999999999998e-1" laneChange="none"/>
                        <speed sOffset="0.0000000000000000e+0" max="5.0000000000000000e+1" unit="km/h"/>
                        <userData>
                            <vectorLane sOffset="0.0000000000000000e+0" laneId="{48ab06f5-95a6-4619-87c7-62ee546b886c}" travelDir="undirected"/>
                        </userData>
                    </lane>
                </left>
                <center>
                    <lane id="0" type="none" level="false">
                        <roadMark sOffset="0.0000000000000000e+0" type="none" material="standard" color="white" laneChange="none"/>
                        <userData/>
                    </lane>
                </center>
                <userData>
                    <vectorLaneSection>
                        <carriageway rightBoundary="0" leftBoundary="0"/>
                        <carriageway rightBoundary="2" leftBoundary="6"/>
                    </vectorLaneSection>
                </userData>
            </laneSection>
        </lanes>
        <objects>
            <object id="3724" name="" s="2.2370522818614873e+0" t="-1.1999960287965052e+0" zOffset="0.0000000000000000e+0" hdg="-1.5707978010177612e+0" roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0" orientation="+" type="parking" width="5.6137487388483009e+0" length="2.4000497443380482e+0">
                <parkingSpace>
                    <marking side="left" type="solid" width="1.2500000000000000e-1" color="white"/>
                    <marking side="right" type="solid" width="1.2500000000000000e-1" color="white"/>
                </parkingSpace>
            </object>
            <object id="3678" name="" s="7.8508094988603379e+0" t="-1.1999960287965337e+0" zOffset="0.0000000000000000e+0" hdg="-1.5707914829254150e+0" roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0" orientation="-" type="parking" width="5.6137811005903586e+0" length="2.4000777932870392e+0">
                <parkingSpace>
                    <marking side="left" type="solid" width="1.2500000000000000e-1" color="white"/>
                    <marking side="right" type="solid" width="1.2500000000000000e-1" color="white"/>
                </parkingSpace>
            </object>
            <object id="3680" name="" s="1.3464566715859196e+1" t="-1.2000031242975524e+0" zOffset="0.0000000000000000e+0" hdg="-1.5707851648330688e+0" roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0" orientation="-" type="parking" width="5.6137619562199461e+0" length="2.4000343150162280e+0">
                <parkingSpace>
                    <marking side="left" type="solid" width="1.2500000000000000e-1" color="white"/>
                    <marking side="right" type="solid" width="1.2500000000000000e-1" color="white"/>
                </parkingSpace>
            </object>
            <object id="3661" name="" s="1.9078295550853763e+1" t="-1.1999960287965052e+0" zOffset="0.0000000000000000e+0" hdg="-1.5708023309707642e+0" roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0" orientation="+" type="parking" width="5.6137369875198999e+0" length="2.4000181614143230e+0">
                <parkingSpace>
                    <marking side="left" type="solid" width="1.2500000000000000e-1" color="white"/>
                    <marking side="right" type="solid" width="1.2500000000000000e-1" color="white"/>
                </parkingSpace>
            </object>
            <object id="3664" name="" s="2.4694206247559720e+1" t="-1.1993188671130781e+0" zOffset="0.0000000000000000e+0" hdg="-1.5689975023269653e+0" roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0" orientation="-" type="parking" width="5.6181360868327488e+0" length="2.4084007378830279e+0">
                <parkingSpace>
                    <marking side="left" type="solid" width="1.2500000000000000e-1" color="white"/>
                    <marking side="right" type="solid" width="1.2500000000000000e-1" color="white"/>
                </parkingSpace>
            </object>
            <object id="3229" name="arrow" s="2.4890178350215781e+1" t="1.7500014136988113e+0" zOffset="0.0000000000000000e+0" hdg="3.1415927410125732e+0" roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0" orientation="+" type="-1" width="1.5739274955203655e+0" length="1.4896625317754797e+0"/>
            <object id="3703" name="" s="3.0305782420943402e+1" t="-1.1984740151482356e+0" zOffset="0.0000000000000000e+0" hdg="-1.5708150863647461e+0" roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0" orientation="+" type="parking" width="5.6205357094759165e+0" length="2.4035673571115694e+0">
                <parkingSpace>
                    <marking side="left" type="solid" width="1.2500000000000000e-1" color="white"/>
                    <marking side="right" type="solid" width="1.2500000000000000e-1" color="white"/>
                </parkingSpace>
            </object>
            <object id="3698" name="" s="3.5919538600040632e+1" t="-1.2000012626155865e+0" zOffset="0.0000000000000000e+0" hdg="-1.5708070993423462e+0" roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0" orientation="+" type="parking" width="5.6137832916110995e+0" length="2.4000308445096152e+0">
                <parkingSpace>
                    <marking side="left" type="solid" width="1.2500000000000000e-1" color="white"/>
                    <marking side="right" type="solid" width="1.2500000000000000e-1" color="white"/>
                </parkingSpace>
            </object>
            <object id="3651" name="" s="4.1533315315094718e+1" t="-1.2000012626155865e+0" zOffset="0.0000000000000000e+0" hdg="-1.5707879066467285e+0" roll="0.0000000000000000e+0" pitch="0.0000000000000000e+0" orientation="-" type="parking" width="5.6137710596839412e+0" length="2.4000252235221069e+0">
                <parkingSpace>
                    <marking side="left" type="solid" width="1.2500000000000000e-1" color="white"/>
                    <marking side="right" type="solid" width="1.2500000000000000e-1" color="white"/>
                </parkingSpace>
            </object>
        </objects>
    </road>
```