### PR TITLE
Permissive flag and w4 fixes

### DIFF
--- a/EnvironmentSimulator/CMakeLists.txt
+++ b/EnvironmentSimulator/CMakeLists.txt
@@ -170,7 +170,7 @@ elseif(UNIX)
     SET(CMAKE_CXX_FLAGS "-march=native -O0 -std=c++14 -pthread -fPIC")  
   else()
     SET(CMAKE_CXX_FLAGS "-std=c++14 -pthread -fPIC -Wl,-strip-all")
-endif()
+  endif()
   
   set ( OSG_LIBRARIES
     optimized osgdb_serializers_osgsim debug osgdb_serializers_osgsimd 
@@ -246,6 +246,10 @@ else() #not UNIX
 
   # Get rid of historical macros preventing SUMO integration
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D NOMINMAX ")
+
+  if ((MSVC) AND (MSVC_VERSION GREATER_EQUAL 1910))
+    add_compile_options(/permissive-)
+  endif ()
   
   set ( OSG_LIBRARIES 
       opengl32.lib

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -115,32 +115,6 @@ static void copyStateFromScenarioGateway(SE_ScenarioObjectState *state, ObjectSt
 	state->height = gw_state->boundingbox.dimensions_.height_;
 }
 
-static void copyStateToScenarioGateway(ObjectStateStruct* gw_state, SE_ScenarioObjectState* state)
-{
-	gw_state->id = state->id;
-	gw_state->model_id = state->model_id;
-	gw_state->ctrl_type = state->ctrl_type;
-	//	strncpy(state->name, gw_state->name, NAME_LEN);
-	gw_state->timeStamp = state->timestamp;
-	gw_state->pos.SetX(state->x);
-	gw_state->pos.SetY(state->y);
-	gw_state->pos.SetZ(state->z);
-	gw_state->pos.SetH(state->h);
-	gw_state->pos.SetP(state->p);
-	gw_state->pos.SetR(state->r);
-	gw_state->speed = state->speed;
-	gw_state->pos.SetTrackPos(state->roadId, state->s, state->t, roadmanager::Position::UpdateTrackPosMode::UPDATE_NOT_XYZH);
-	gw_state->pos.SetLaneId(state->laneId);
-	gw_state->pos.SetS(state->s);
-	gw_state->pos.SetOffset(state->laneOffset);
-	gw_state->boundingbox.center_.x_ = state->centerOffsetX;
-	gw_state->boundingbox.center_.y_ = state->centerOffsetY;
-	gw_state->boundingbox.center_.z_ = state->centerOffsetZ;
-	gw_state->boundingbox.dimensions_.width_ = state->width;
-	gw_state->boundingbox.dimensions_.length_ = state->length;
-	gw_state->boundingbox.dimensions_.height_ = state->height;
-}
-
 static int GetRoadInfoAtDistance(int object_id, float lookahead_distance, SE_RoadInfo *r_data, int lookAheadMode)
 {
 	roadmanager::RoadProbeInfo s_data;

--- a/EnvironmentSimulator/Modules/CommonMini/CommonMini.cpp
+++ b/EnvironmentSimulator/Modules/CommonMini/CommonMini.cpp
@@ -235,8 +235,6 @@ double PointToLineDistance2DSigned(double px, double py, double lx0, double ly0,
 {
 	double l0x = lx1 - lx0;
 	double l0y = ly1 - ly0;
-	double l1x = px - lx0;
-	double l1y = py - ly0;
 	double cp = GetCrossProduct2D(lx1 - lx0, ly1 - ly0, px - lx0, py - ly0);
 	double l0Length = sqrt(l0x * l0x + l0y * l0y);
 	return cp / l0Length;
@@ -364,7 +362,6 @@ double strtod(std::string s)
 double SE_getSimTimeStep(__int64 &time_stamp, double min_time_step, double max_time_step)
 {
 	double dt;
-	double adjust = 0;
 	__int64 now = SE_getSystemTime();
 
 	dt = (now - time_stamp) * 0.001;  // step size in seconds

--- a/EnvironmentSimulator/Modules/Controllers/ControllerFollowGhost.cpp
+++ b/EnvironmentSimulator/Modules/Controllers/ControllerFollowGhost.cpp
@@ -83,7 +83,7 @@ void ControllerFollowGhost::Step(double timeStep)
 	// Find out a steering target along ghost vehicle trail
 	double s_out;
 	int index_out;
-	ObjectTrailState state;
+	ObjectTrailState state = {0, 0, 0, 0, 0, 0};
 
 	// Locate a point at given distance from own vehicle along the ghost trajectory
 	if (object_->GetGhost() && object_->GetGhost()->trail_.FindPointAhead(

--- a/EnvironmentSimulator/Modules/Controllers/vehicle.cpp
+++ b/EnvironmentSimulator/Modules/Controllers/vehicle.cpp
@@ -162,8 +162,6 @@ void Vehicle::DrivingControlAnalog(double dt, double throttle, double steering)
 
 void Vehicle::Update(double dt)
 {
-	double criticalB = 0;
-
 	// Calculate wheel rot: https://en.wikipedia.org/wiki/Arc_(geometry)
 	wheelRotation_ = fmod(wheelRotation_ + speed_ * dt / WHEEL_RADIUS, 2 * M_PI);
 

--- a/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp
+++ b/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp
@@ -547,7 +547,6 @@ int ScenarioPlayer::InitViewer()
 void viewer_thread(void *args)
 {
 	ScenarioPlayer *player = (ScenarioPlayer*)args;
-	__int64 time_stamp = 0;
 
 	if (player->InitViewer() != 0)
 	{

--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -435,8 +435,6 @@ void Poly3::EvaluateDS(double ds, double *x, double *y, double *h)
 
 double Poly3::EvaluateCurvatureDS(double ds)
 {
-	double p = (ds / GetLength()) * GetUMax();
-
 	return poly3_.EvaluatePrimPrim(ds);
 }
 
@@ -1166,7 +1164,7 @@ RoadMarkInfo Lane::GetRoadMarkInfoByS(int track_id, int lane_id, double s)
 	LaneRoadMarkTypeLine *lane_roadMarkTypeLine;
 	RoadMarkInfo rm_info;
 	int lsec_idx, number_of_lsec, number_of_roadmarks, number_of_roadmarktypes, number_of_roadmarklines;
-	double s_roadmark, s_roadmarkline, s_end_roadmark, s_end_roadmarkline, lsec_end;
+	double s_roadmark, s_roadmarkline, s_end_roadmark, s_end_roadmarkline = 0, lsec_end = 0;
 	if (road == 0)
 	{
 		LOG("Position::Set Error: track %d not available\n", track_id);
@@ -1188,7 +1186,7 @@ RoadMarkInfo Lane::GetRoadMarkInfoByS(int track_id, int lane_id, double s)
 		number_of_lsec = road->GetNumberOfLaneSections();
 		if (lsec_idx == number_of_lsec-1)
 		{
-			lsec_end = road->GetLength();	
+			lsec_end = road->GetLength();
 		}
 		else
 		{
@@ -2811,8 +2809,6 @@ void Junction::Print()
 
 bool RoadPath::CheckRoad(Road *checkRoad, RoadPath::PathNode *srcNode, Road *fromRoad)
 {
-	Road* targetRoad = targetPos_->GetOpenDrive()->GetRoadById(targetPos_->GetTrackId());
-	
 	RoadLink* nextLink = 0;
 
 	if (srcNode->link->GetElementType() == RoadLink::RoadLink::ELEMENT_TYPE_ROAD)
@@ -2939,8 +2935,6 @@ int RoadPath::Calculate(double &dist)
 
 	if (startRoad == targetRoad)
 	{
-		int direction = 0;
-
 		dist = targetPos_->GetS() - startPos_->GetS();
 
 		// Special case: On same road, distance is equal to delta s
@@ -4417,7 +4411,6 @@ int Position::XYZH2TrackPos(double x3, double y3, double z3, double h3, bool ali
 	double angle = 0;
 	bool search_done = false;
 	double closestS = 0;
-	int laneSectionMinIndex = -1;
 	int j2, k2, jMin=-1, kMin=-1, jMinLocal, kMinLocal;
 	double closestPointDist = INFINITY;
 
@@ -4511,10 +4504,9 @@ int Position::XYZH2TrackPos(double x3, double y3, double z3, double h3, bool ali
 			// Find closest line or point
 			for (int k = 0; k < osiPoints->GetNumOfOSIPoints(); k++)
 			{
-				double distTmp;
+				double distTmp = 0;
 				OSIPoints::OSIPointStruct &osi_point = osiPoints->GetPoint(k);
 				double z = osi_point.z;
-				double lateralOffset = 0;
 				bool inside = false;
 
 				double cp = GetCrossProduct2D(cos(osi_point.h), sin(osi_point.h), x3 - osi_point.x, y3 - osi_point.y);
@@ -5420,8 +5412,6 @@ int Position::MoveAlongS(double ds, double dLaneOffset, Junction::JunctionStrate
 int Position::SetLanePos(int track_id, int lane_id, double s, double offset, int lane_section_idx)
 {
 	offset_ = offset;
-	int old_lane_id = lane_id_;
-	int old_track_id = track_id_;
 	int retvalue;
 	
 	if ((retvalue = SetLongitudinalTrackPos(track_id, s)) != ErrorCode::ERROR_NO_ERROR)
@@ -6551,8 +6541,6 @@ int Position::MoveTrajectoryDS(double ds)
 int Position::SetTrajectoryPosByTime(Trajectory* trajectory, double time)
 {
 	double s = 0;
-	double incr_time = 0;
-	double tot_dist = 0;
 
 	// Find out corresponding S-value
 	size_t i = 0;
@@ -6641,9 +6629,6 @@ int Position::SetTrajectoryS(Trajectory* trajectory, double traj_s)
 			{
 				// At segment, make a linear interpolation
 				double a = (traj_s - tot_dist) / dist; // a = interpolation factor
-				double x = (1 - a) * vp0->GetX() + a * vp1->GetX();
-				double y = (1 - a) * vp0->GetY() + a * vp1->GetY();
-				double z = (1 - a) * vp0->GetZ() + a * vp1->GetZ();
 
 				SetInertiaPos(
 					(1 - a) * vp0->GetX() + a * vp1->GetX(),

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCAction.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCAction.hpp
@@ -121,7 +121,7 @@ namespace scenarioengine
 
 		virtual void End()
 		{
-			if (State::RUNNING)
+			if (state_ == State::RUNNING)
 			{
 				transition_ = Transition::END_TRANSITION;
 				if (type_ == ElementType::ACT || num_executions_ >= max_num_executions_)

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCAction.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCAction.hpp
@@ -108,7 +108,7 @@ namespace scenarioengine
 
 		virtual void Stop()
 		{
-			if (state_ == State::STANDBY || State::RUNNING)
+			if (state_ == State::STANDBY || state_ == State::RUNNING)
 			{
 				transition_ = Transition::STOP_TRANSITION;
 				next_state_ = State::COMPLETE;

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCCondition.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCCondition.cpp
@@ -405,7 +405,7 @@ bool TrigByTimeToCollision::CheckCondition(StoryBoard* storyBoard, double sim_ti
 
 	bool result = false;
 	double rel_dist, ttc = 0, rel_speed;
-	roadmanager::Position* pos;
+	roadmanager::Position* pos = nullptr;
 	if (object_)
 	{
 		pos = &object_->pos_;

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
@@ -132,8 +132,6 @@ void FollowTrajectoryAction::Step(double dt, double simTime)
 	time_ += timing_scale_ * dt;
 
 	// Measure length of movement for odometer
-	double x0 = object_->pos_.GetX();
-	double y0 = object_->pos_.GetY();
 
 	if (!traj_->closed_ && object_->pos_.GetTrajectoryS() > (traj_->shape_->length_ - DISTANCE_TOLERANCE))
 	{
@@ -582,7 +580,7 @@ void LongDistanceAction::Step(double dt, double simTime)
 	double acc;
 	double spring_constant = 4;
 	double dc;
-	double requested_dist;
+	double requested_dist = 0;
 
 	// Just interested in the x-axis component of the distance
 	distance = x;
@@ -1152,8 +1150,8 @@ void SynchronizeAction::Step(double dt, double simTime)
 		else
 		{
 			// No final speed specified. Calculate it based on current speed and available time
-			double final_speed_ = 2 * average_speed - object_->speed_;
-			acc = (final_speed_ - object_->speed_) / masterTimeToDest;
+			double final_speed = 2 * average_speed - object_->speed_;
+			acc = (final_speed - object_->speed_) / masterTimeToDest;
 		}
 
 		object_->SetSpeed(object_->GetSpeed() + acc * dt);

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
@@ -257,7 +257,6 @@ int OSIReporter::UpdateOSIGroundTruth(std::vector<ObjectState*> objectState)
 {
 	obj_osi_internal.gt->clear_moving_object();
 	obj_osi_internal.gt->clear_stationary_object();
-	double time_stamp = objectState[0]->state_.timeStamp;
 
 	obj_osi_internal.gt->mutable_timestamp()->set_seconds((int64_t)objectState[0]->state_.timeStamp);
 	obj_osi_internal.gt->mutable_timestamp()->set_nanos((uint32_t)(
@@ -544,7 +543,6 @@ int OSIReporter::UpdateOSILaneBoundary(std::vector<ObjectState*> objectState)
 							// loop over LaneRoadMarkTypeLine
 							for (int kk = 0; kk< laneroadmarktype->GetNumberOfRoadMarkTypeLines(); kk++)
 							{
-								int num_lines = laneroadmarktype->GetNumberOfRoadMarkTypeLines();
 								roadmanager::LaneRoadMarkTypeLine* laneroadmarktypeline = laneroadmarktype->GetLaneRoadMarkTypeLineByIdx(kk);
 
 								osi3::LaneBoundary* osi_laneboundary = 0;
@@ -578,7 +576,6 @@ int OSIReporter::UpdateOSILaneBoundary(std::vector<ObjectState*> objectState)
 
 									// update classification type
 									osi3::LaneBoundary_Classification_Type classific_type;
-									roadmanager::LaneRoadMark::RoadMarkType tyype = laneroadmark->GetType();
 									osi3::LaneBoundary_Classification_Type osi_type = osi_laneboundary->mutable_classification()->type();
 									switch(laneroadmark->GetType())
 									{
@@ -742,7 +739,7 @@ int OSIReporter::UpdateOSIRoadLane(std::vector<ObjectState*> objectState)
 
 						// CLASSIFICATION TYPE
 						roadmanager::Lane::LaneType lanetype = lane->GetLaneType();
-						osi3::Lane_Classification_Type class_type;
+						osi3::Lane_Classification_Type class_type = osi3::Lane_Classification_Type::Lane_Classification_Type_TYPE_UNKNOWN;
 
 						if (lanetype == roadmanager::Lane::LaneType::LANE_TYPE_DRIVING 		||
 							lanetype == roadmanager::Lane::LaneType::LANE_TYPE_PARKING		||
@@ -803,7 +800,6 @@ int OSIReporter::UpdateOSIRoadLane(std::vector<ObjectState*> objectState)
 						osi_lane->mutable_classification()->set_centerline_is_driving_direction(driving_direction);
 
 						// LEFT AND RIGHT LANE IDS
-						int n_lanes_in_section = lane_section->GetNumberOfLanes();
 						std::vector< std::pair <int,int> > globalid_ids_left;
 						std::vector< std::pair <int,int> > globalid_ids_right;
 
@@ -855,7 +851,6 @@ int OSIReporter::UpdateOSIRoadLane(std::vector<ObjectState*> objectState)
 						// STILL TO DO: when I get a vector of predecessors and successors I need to create all possible combinations
 						roadmanager::LaneLink* lane_pre = lane->GetLink(roadmanager::LinkType::PREDECESSOR);
 						roadmanager::LaneLink* lane_succ = lane->GetLink(roadmanager::LinkType::SUCCESSOR);
-						bool exist_link = false;
 						if (lane_pre != 0)
 						{
 							osi3::Lane_Classification_LanePairing* lane_pair = osi_lane->mutable_classification()->add_lane_pairing();

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
@@ -357,8 +357,6 @@ ScenarioGateway *ScenarioEngine::getScenarioGateway()
 
 void ScenarioEngine::parseScenario()
 {
-	bool hybrid_objects = false;
-
 	if (!disable_controllers_)
 	{
 		scenarioReader->LoadControllers();
@@ -471,7 +469,7 @@ void ScenarioEngine::defaultController(Object* obj, double dt)
 
 	if (obj->pos_.GetRoute() && !obj->CheckDirtyBits(Object::DirtyBit::LATERAL))
 	{
-		int retvalue = obj->pos_.MoveRouteDS(steplen);
+		retvalue = obj->pos_.MoveRouteDS(steplen);
 
 		if (retvalue == roadmanager::Position::ErrorCode::ERROR_END_OF_ROUTE)
 		{

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioReader.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioReader.cpp
@@ -1352,7 +1352,7 @@ OSCPrivateAction *ScenarioReader::parseOSCPrivateAction(pugi::xml_node actionNod
 						}
 						else if (laneChangeChild.name() == std::string("LaneChangeTarget"))
 						{
-							LatLaneChangeAction::Target *target;
+							LatLaneChangeAction::Target *target = nullptr;
 
 							for (pugi::xml_node targetChild = laneChangeChild.first_child(); targetChild; targetChild = targetChild.next_sibling())
 							{
@@ -1401,7 +1401,7 @@ OSCPrivateAction *ScenarioReader::parseOSCPrivateAction(pugi::xml_node actionNod
 						}
 						else if (laneOffsetChild.name() == std::string("LaneOffsetTarget"))
 						{
-							LatLaneOffsetAction::Target *target;
+							LatLaneOffsetAction::Target *target = nullptr;
 
 							for (pugi::xml_node targetChild = laneOffsetChild.first_child(); targetChild; targetChild = targetChild.next_sibling())
 							{

--- a/EnvironmentSimulator/Modules/ViewerBase/viewer.cpp
+++ b/EnvironmentSimulator/Modules/ViewerBase/viewer.cpp
@@ -165,7 +165,6 @@ SensorViewFrustum::SensorViewFrustum(ObjectSensor *sensor, osg::Group *parent)
 
 	size_t i;
 	unsigned int idx = 0;
-	unsigned int idx2 = 0;
 	unsigned int idxC = 0;
 
 	for (i = 0; i < numSegments+1; ++i, angle += angleDelta)
@@ -1055,8 +1054,7 @@ EntityModel* Viewer::AddEntityModel(std::string modelFilepath, osg::Vec3 trail_c
 	{
 		file_name_candidates.push_back(CombineDirectoryPathAndFilepath(SE_Env::Inst().GetPaths()[i], path));
 	}
-	size_t i;
-	for (i = 0; i < file_name_candidates.size(); i++)
+	for (size_t i = 0; i < file_name_candidates.size(); i++)
 	{
 		if (FileExists(file_name_candidates[i].c_str()))
 		{
@@ -1407,7 +1405,7 @@ bool Viewer::CreateRoadLines(roadmanager::OpenDrive* od)
 		osg::ref_ptr<osg::Vec4Array> kp_color = new osg::Vec4Array;
 		osg::ref_ptr<osg::Point> kp_point = new osg::Point();
 
-		roadmanager::Geometry *geom;
+		roadmanager::Geometry *geom = nullptr;
 		for (int i = 0; i < road->GetNumberOfGeometries()+1; i++)
 		{
 			if (i < road->GetNumberOfGeometries())


### PR DESCRIPTION
Added /permissive- flag when compiling with Visual Studio and fixed some /W4 warnings.
- Removed unused function copyStateToScenarioGateway.
- Removed unused variables.
- Fixed use of potentially uninitialized variables.
- Fixed bug in OSCAction.hpp.
- Fixed a few "hiding of variable" warnings (OSCPrivateAction.hpp:1155, ScenarioEngine.cpp:472, viewer.cpp:1057)

I would suggest adding the /W4 compile flag as well, there aren't that many warnings overall, so it should be possible to fix all of them. Many of them are C4100 "unreferenced formal parameter" which I find a bit useless, that could be disabled manually with /wd4100, or easily fixed by not naming the unreferenced parameter.