### PR TITLE
Update OdrPlot to add sampling rate and output file command line arguments

### DIFF
--- a/EnvironmentSimulator/Applications/odrplot/main.cpp
+++ b/EnvironmentSimulator/Applications/odrplot/main.cpp
@@ -28,10 +28,25 @@ using namespace roadmanager;
 
 int main(int argc, char *argv[])
 {
+	
+	std::string filename = "track.csv";
+	std::string samplingstep = "1.0";
+	double step_length_target;
+	
 	if (argc < 2)
 	{
-		printf("Usage: roadmanager <OpenDRIVE filename>\n");
+		printf("Usage: ordplot openDriveFile.xodr [Output file, default=output.csv] [samplingStep, default=1.0]\n");
+		exit(0);
+	}else {
+		if (argc > 2){
+			filename =  argv[2];
+		}
+		if (argc > 3){
+			samplingstep = argv[3];
+			step_length_target = std::stod(samplingstep);
+		}
 	}
+	
 	try
 	{
 		Position::LoadOpenDrive(argv[1]);
@@ -40,12 +55,13 @@ int main(int argc, char *argv[])
 	{ 
 		LOG("exception: %s", e.what()); 
 	}
+	
 
 	std::ofstream file;
-	file.open("track.csv");
+	file.open(filename);
 
 	Position* pos = new Position();
-	double step_length_target = 1;
+	
 	OpenDrive *od = Position::GetOpenDrive();
 
 	for (int r = 0; r < od->GetNumOfRoads(); r++)

--- a/EnvironmentSimulator/Applications/odrplot/main.cpp
+++ b/EnvironmentSimulator/Applications/odrplot/main.cpp
@@ -29,36 +29,34 @@ using namespace roadmanager;
 int main(int argc, char *argv[])
 {
 	
-	std::string filename = "track.csv";
-	std::string samplingstep = "1.0";
+	std::string output_file_name = "track.csv";
+	std::ofstream file;
+	std::string sampling_step = "1.0";
 	double step_length_target;
 	
 	if (argc < 2)
 	{
-		printf("Usage: ordplot openDriveFile.xodr [Output file, default=output.csv] [samplingStep, default=1.0]\n");
+		printf("Usage: ordplot openDriveFile.xodr [Output file, default=output.csv] [Sampling_step, default=1.0]\n");
 		exit(0);
 	}else {
 		if (argc > 2){
-			filename =  argv[2];
+			output_file_name =  argv[2];
 		}
 		if (argc > 3){
-			samplingstep = argv[3];
-			step_length_target = std::stod(samplingstep);
+			sampling_step = argv[3];
+			step_length_target = std::stod(sampling_step);
 		}
 	}
 	
 	try
 	{
 		Position::LoadOpenDrive(argv[1]);
+		file.open(output_file_name);
 	}
 	catch (std::exception& e) 
 	{ 
 		LOG("exception: %s", e.what()); 
 	}
-	
-
-	std::ofstream file;
-	file.open(filename);
 
 	Position* pos = new Position();
 	


### PR DESCRIPTION
I also noticed that `EnvironmentSimulator/Applications/odrplot/xodr.py` is not present in the release binary package to draw the plot. It may be intentional but I thought it is important to bring it up. 

Changes:
- Better error handling when the filename is not passed, exit(0)
- Sampling rate and output csv file as a part of command line arguments