### PR TITLE
Superelevation support: Fix for non-consideration of laneOffset in t

### DIFF
--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -1748,7 +1748,7 @@ bool Road::UpdateZAndRollBySAndT(double s, double t, double *z, double *roll, in
 		{
 			double ds = s - super_elevation->GetS();
 			*roll = super_elevation->poly3_.Evaluate(ds);
-			*z += sin(*roll) * t;
+			*z += sin(*roll) * (t + GetLaneOffset(s));
 
 			return true;
 		}


### PR DESCRIPTION
Dear Emil,

as discussed in https://github.com/esmini/esmini/issues/72, this is the PR that corrects the superelevation for laneOffset.

All the best,
Christoph