### PR TITLE
Bugfix - avoid "faulty" relative hpr

### DIFF
--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -6257,14 +6257,17 @@ int Position::SetInertiaPos(double x, double y, double z, double h, double p, do
 	x_ = x;
 	y_ = y;
 	z_ = z;
-	h_ = h;
-	p_ = p;
-	r_ = r;
 
 	if (updateTrackPos)
 	{
 		XYZ2Track(false);
 	}
+
+	// Now when road orientation is known, call functions for 
+	// updating angels both absolute and relative the road 
+	SetHeading(h);
+	SetPitch(p);
+	SetRoll(r);
 
 	return 0;
 }
@@ -6273,12 +6276,15 @@ int Position::SetInertiaPos(double x, double y, double h, bool updateTrackPos)
 {
 	x_ = x;
 	y_ = y;
-	SetHeading(h);
 
 	if (updateTrackPos)
 	{
 		XYZ2Track(true);
 	}
+
+	// Now when road orientation is known, call functions for 
+	// updating angels both absolute and relative the road 
+	SetHeading(h);
 
 	return 0;
 }

--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -6257,9 +6257,9 @@ int Position::SetInertiaPos(double x, double y, double z, double h, double p, do
 	x_ = x;
 	y_ = y;
 	z_ = z;
-	SetHeading(h);
-	SetPitch(p);
-	SetRoll(r);
+	h_ = h;
+	p_ = p;
+	r_ = r;
 
 	if (updateTrackPos)
 	{

--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -6264,7 +6264,7 @@ int Position::SetInertiaPos(double x, double y, double z, double h, double p, do
 	}
 
 	// Now when road orientation is known, call functions for 
-	// updating angels both absolute and relative the road 
+	// updating angles both absolute and relative the road 
 	SetHeading(h);
 	SetPitch(p);
 	SetRoll(r);
@@ -6283,7 +6283,7 @@ int Position::SetInertiaPos(double x, double y, double h, bool updateTrackPos)
 	}
 
 	// Now when road orientation is known, call functions for 
-	// updating angels both absolute and relative the road 
+	// updating angles both absolute and relative the road 
 	SetHeading(h);
 
 	return 0;


### PR DESCRIPTION
Hi Emil,

working with the latest 2.4.4 release, I believe to have found the following bug:

1. Using an XOSC with TeleportAction/WorldPosition, SetInertiaPos is called from OSCPositionWorld.
2. SetInertiaPos calls SetHeading/SetPitch/SetRoll
3. In SetHeading/SetPitch/SetRoll not only the values for h_/p_/r_ are calculated but also relative values compared to the road (such as h_relative_)
4. However, h_road_, r_road_, p_road_ are still 0.0 at this point - leading to faulty values being set for the relative h/p/r

Fix: I'd suggest to just set h_, p_ and r_ directly as in the PR.

Update: This PR seems fine now.