### PR TITLE
Bugfix - LaneChange over end-to-end/start-to-start road succession

### DIFF
--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
@@ -313,7 +313,7 @@ void LatLaneChangeAction::Step(double dt, double)
 	double angle = 0;
 
 	// Detect whether t switched sign due to end-to-end/start-to-start succession of roads
-	if (fabs(t_old + object_->pos_.GetT()) < SMALL_NUMBER && fabs(t_old) > SMALL_NUMBER)
+	if (SIGN(object_->pos_.GetT()) != SIGN(t_old) && fabs(t_old + object_->pos_.GetT()) < SMALL_NUMBER)
 	{
 		start_t_ *= -1;
 		target_t_ *= -1;

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
@@ -312,6 +312,14 @@ void LatLaneChangeAction::Step(double dt, double)
 	double factor;
 	double angle = 0;
 
+	// Detect whether t switched sign due to end-to-end/start-to-start succession of roads
+	if (fabs(t_old + object_->pos_.GetT()) < SMALL_NUMBER && fabs(t_old) > SMALL_NUMBER)
+	{
+		start_t_ *= -1;
+		target_t_ *= -1;
+		t_old *= -1;
+	}
+
 	if (object_->GetControllerMode() == Controller::Mode::MODE_OVERRIDE &&
 		object_->IsControllerActiveOnDomains(Controller::Domain::CTRL_LATERAL))
 	{


### PR DESCRIPTION
Hi Emil,

once again - we think to have discovered a bug, offering a "quick fix" with the following PR. :)

Bug description: When performing a lane change while transitioning over a "end-to-end" transition between two roads (e.g. OpenDRIVE "<successor elementType="road" elementId="ID" contactPoint="end" />), the vehicle will jump to the opposite site of the reference line (continuing to drive on the oncoming lane). This is because the target lane (or target_t, respectively) is not corrected for the switch in direction of the t-axis at such transition.

I am not sure whether the offered solution is sufficient - maybe there is a better way to detect the transition then checking whether the t-value changed sign?!

All the best,
Christoph