### PR TITLE
Fixed an issue where LaneSection::GetClosestLaneIdx() would return closest lane center instead of closest actual lane

### DIFF
--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -5114,6 +5114,13 @@ int LaneSection::GetClosestLaneIdx(double s, double t, double &offset, bool noZe
 		// Only consider lanes with matching lane type
 		if (laneTypeMask & GetLaneById(lane_id)->GetLaneType() && (!noZeroWidth || GetWidth(s, lane_id) > SMALL_NUMBER))
 		{
+			// If position is within a lane, we can return it without further checks
+			if (fabs(t - laneCenterOffset) < (GetWidth(s, lane_id) / 2.))
+			{
+				min_offset = t - laneCenterOffset;
+				candidate_lane_idx = i;
+				break;
+			}
 			if (candidate_lane_idx == -1 || fabs(t - laneCenterOffset) < fabs(min_offset))
 			{
 				min_offset = t - laneCenterOffset;


### PR DESCRIPTION
Hi Emil,

I recently encountered a small issue in `LaneSection::GetClosestLaneIdx()`. Basically, the current implementation returns the lane which center is closest to the given position, which isn't always the lane that is actually closest to the given position.

As always, I'll try to illustrate it as best I can so that you can get a clear picture of what's going on. I'm still using the same OpenDRIVE as reference, so you can check it out for yourself if you still have the file (it's road 61). But this issue is fairly trivial to reproduce on any network.

![image](https://user-images.githubusercontent.com/53508707/123029534-92448b00-d3e1-11eb-8f60-19846b4ee5ad.png)

This road is fairly basic, it has two driving lanes (one for each side), and multiple side lanes for gutter, curb, sidewalk (which are created by default in RoadRunner).

I'm still using my small gizmo thing that displays the OpenDRIVE coordinate on the right panel. As you can see below, I've added lines for where the actual lane borders are (the green one is slightly offset in the first video, but that's not an issue). RoadManager switches from lane -1 to -2 way too early. If you look closely to the `T` value, you'll notice that it switches when at -100 (I'm using Unreal's default unit, which is centimeter), even though the lane is 3.5m wide.

![vhcd - Unreal Editor 2021-06-23 05-04-00 mp4](https://user-images.githubusercontent.com/53508707/123029794-f9623f80-d3e1-11eb-9700-a6da19af0d59.gif)

This is caused by the current implementation of `LaneSection::GetClosestLaneIdx()`, which only tries to minimize distance to the lane center, and doesn't check if the given position is within the lane or not. In my case, since I have a 3.5m lane right next to a ~0.5m lane, it leads to the switch occurring at the middle ground between the two lane's centers, and not at their border.

https://github.com/esmini/esmini/blob/ed40daf228f70336772fd48530c0b5134f39263e/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp#L5117-L5121

This PR adds an additional check in `LaneSection::GetClosestLaneIdx()` to see if the given position is within a lane, in which case it returns that lane without more checks. I've only tested it on my broken use-case, but as you can see below, it seems to work.

![vhcd - Unreal Editor 2021-06-23 05-06-25 mp4](https://user-images.githubusercontent.com/53508707/123030491-311db700-d3e3-11eb-8cfd-f9cd6770bfdb.gif)

This change might have a lot of side effects that I didn't consider, since I don't really know what methods rely on `LaneSection::GetClosestLaneIdx()` and its current implementation. Maybe the "snap to closest center" actually is needed by some callers, and the new "snap to closest" would break them. I hope you have the answer to that, so that you can decide whether to merge this PR, or otherwise maybe split the method in two, like `LaneSection::GetClosestLaneIdx()` and `LaneSection::GetClosestLaneCenterIdx()` so that we can still have the two behaviors.

And as always, thank you for you amazing work on esmini!

Bertrand