### PR TITLE
Handling of situations, if next vehicle in front of cut-out vehicle comes first in for loop

### DIFF
--- a/EnvironmentSimulator/Modules/Controllers/ControllerECE_ALKS_DRIVER.cpp
+++ b/EnvironmentSimulator/Modules/Controllers/ControllerECE_ALKS_DRIVER.cpp
@@ -126,7 +126,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 					// TTC (<= 2sec) + offset (> 0.375) + perception time (0.4sec, see plot of regulation)
 					waitTime_ = 1.15;  // 0.75sec braking delay + 0.4sec risk perception time (distance a and b in plot of regulation)
 					ALKS_LOG("ECE ALKS driver -> cut-in detected of '%s' (TTC: %.2f) -> driver starts braking after %.2f sec (braking delay + risk perception time)",
-						entities_->object_[i]->name_, TTC, waitTime_);
+						entities_->object_[i]->name_.c_str(), TTC, waitTime_);
 					driverBraking_ = true;
 				}
 			}
@@ -139,12 +139,12 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 					// relative heading angles are playing no role for reference driver
 					if (dtFreeCutOut_ == -LARGE_NUMBER)
 					{
-						ALKS_LOG("ECE ALKS driver -> cut-out detected of '%s'", entities_->object_[i]->name_);
+						ALKS_LOG("ECE ALKS driver -> cut-out detected of '%s'", entities_->object_[i]->name_.c_str());
 						if (!driverBrakeCandidateName.empty())
 						{
 							waitTime_ = 1.15;  // 0.75sec braking delay + 0.4sec risk perception time (distance a and b in plot of regulation)
 							ALKS_LOG("ECE ALKS driver -> cut-out '%s' and next vehicle in front '%s' detected (TTC: %.2f) -> "
-								"start braking after %.2f sec (braking delay + risk perception time)", entities_->object_[i]->name_,
+								"start braking after %.2f sec (braking delay + risk perception time)", entities_->object_[i]->name_.c_str(),
 								driverBrakeCandidateName, TTC, waitTime_);
 							driverBraking_ = true;
 						}
@@ -153,7 +153,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 					dtFreeCutOut_ = fabs(diff.dt) - 0.5 * (egoW + targetW);
 					if (!aebBrakeCandidateName.empty() && dtFreeCutOut_ >= 0)
 					{
-						ALKS_LOG("ECE ALKS AEB -> full wrap of '%s' and '%s' (TTC: %.2f) -> AEB starts braking", object_->name_, aebBrakeCandidateName,
+						ALKS_LOG("ECE ALKS AEB -> full wrap of '%s' and '%s' (TTC: %.2f) -> AEB starts braking", object_->name_.c_str(), aebBrakeCandidateName,
 							aebBrakeCandidateTTC);
 						// AEB brakes harder than driver, no need to continue checking for scenario if aeb is already braking
 						aebBraking_ = true;
@@ -174,12 +174,12 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 						{
 							waitTime_ += 0.4;  // + 0.4sec risk perception time which begins when leading vehicle exceeds a deceleration of 5m/s2
 							ALKS_LOG("ECE ALKS driver -> deceleration detected of '%s' (as: %.2f, TTC: %.2f) -> driver starts braking after %.2f sec "
-								"(braking delay + risk perception time)", entities_->object_[i]->name_, fabs(targetAS), TTC, waitTime_);
+								"(braking delay + risk perception time)", entities_->object_[i]->name_.c_str(), fabs(targetAS), TTC, waitTime_);
 						}
 						else
 						{
 							LOG("ECE ALKS driver -> deceleration detected of '%s' (as: %.2f, TTC: %.2f) -> driver starts braking after %.2f sec "
-								"(braking delay, no risk perception time)", entities_->object_[i]->name_, fabs(targetAS), TTC, waitTime_);
+								"(braking delay, no risk perception time)", entities_->object_[i]->name_.c_str(), fabs(targetAS), TTC, waitTime_);
 						}
 						driverBraking_ = true;
 					}
@@ -191,7 +191,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 					// Thus one can directly brake with AEB
 					if (fabs(diff.dt) < SMALL_NUMBER)
 					{
-						ALKS_LOG("ECE ALKS AEB -> full wrap of '%s' and '%s' (TTC: %.2f) -> AEB starts braking", object_->name_, entities_->object_[i]->name_, TTC);
+						ALKS_LOG("ECE ALKS AEB -> full wrap of '%s' and '%s' (TTC: %.2f) -> AEB starts braking", object_->name_.c_str(), entities_->object_[i]->name_.c_str(), TTC);
 						aebBraking_ = true;
 						// AEB brakes harder than driver, no need to continue checking for scenario if aeb is already braking
 						break;
@@ -207,7 +207,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 						// cut-out scenario or cut-in scenario have already been detected before
 						if (dtFreeCutOut_ >= 0 || driverBraking_)
 						{
-							ALKS_LOG("ECE ALKS AEB -> full wrap of '%s' and '%s' (TTC: %.2f) -> AEB starts braking", object_->name_, entities_->object_[i]->name_, TTC);
+							ALKS_LOG("ECE ALKS AEB -> full wrap of '%s' and '%s' (TTC: %.2f) -> AEB starts braking", object_->name_.c_str(), entities_->object_[i]->name_.c_str(), TTC);
 							// AEB brakes harder than driver, no need to continue checking for scenario if aeb is already braking
 							aebBraking_ = true;
 							break;
@@ -230,7 +230,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 						{
 							waitTime_ = 1.15;  // 0.75sec braking delay + 0.4sec risk perception time (distance a and b in plot of regulation)
 							ALKS_LOG("ECE ALKS driver -> cut-out '%s' and next vehicle in front '%s' detected (TTC: %.2f) -> "
-								"driver starts braking after %.2f sec (braking delay + risk perception time)", driverBrakeCandidateName, entities_->object_[i]->name_,
+								"driver starts braking after %.2f sec (braking delay + risk perception time)", driverBrakeCandidateName, entities_->object_[i]->name_.c_str(),
 								TTC, waitTime_);
 							driverBraking_ = true;
 						}
@@ -261,7 +261,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 			// MAX comparing to 0, because it makes no sense to drive backwards
 			acc = timeSinceBraking_ / 0.6 * 0.85;
 			currentSpeed_ = MAX(0, egoV - acc * 9.81 * timeStep);
-			ALKS_LOG("ECE ALKS AEB -> '%s' braking from %.2f to %.2f (acc: %.3fG)", object_->name_, egoV, currentSpeed_, MIN(acc, egoV / timeStep / 9.81));
+			ALKS_LOG("ECE ALKS AEB -> '%s' braking from %.2f to %.2f (acc: %.3fG)", object_->name_.c_str(), egoV, currentSpeed_, MIN(acc, egoV / timeStep / 9.81));
 		}
 		// now the reference driver would brake
 		else if (driverBraking_)
@@ -274,7 +274,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 				// MAX comparing to 0, because it makes no sense to drive backwards
 				acc = timeSinceBraking_ / 0.6 * 0.774;
 				currentSpeed_ = MAX(0, egoV - acc * 9.81 * timeStep);
-				ALKS_LOG("ECE ALKS driver -> wait time passed -> '%s' braking from %.2f to %.2f (acc: %.3fG)", object_->name_, egoV,
+				ALKS_LOG("ECE ALKS driver -> wait time passed -> '%s' braking from %.2f to %.2f (acc: %.3fG)", object_->name_.c_str(), egoV,
 					currentSpeed_, MIN(acc, egoV / timeStep / 9.81));
 			}
 			waitTime_ = MAX(0.0, waitTime_ - timeStep);  // reduce waitTime by current timeStep each time this if branch is called

--- a/EnvironmentSimulator/Modules/Controllers/ControllerECE_ALKS_DRIVER.cpp
+++ b/EnvironmentSimulator/Modules/Controllers/ControllerECE_ALKS_DRIVER.cpp
@@ -58,6 +58,9 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 	double minDist = 15.0;  // minimum distance to keep to lead vehicle
 	double maxDeceleration = -10.0;
 	double normalAcceleration = 3.0;
+	std::string aebBrakeCandidateName = "";
+	double aebBrakeCandidateTTC = LARGE_NUMBER;
+	std::string driverBrakeCandidateName = "";
 
 	double egoL = object_->boundingbox_.dimensions_.length_;
 	double egoW = object_->boundingbox_.dimensions_.width_;
@@ -81,10 +84,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 	// https://www.symbolab.com/solver/equation-calculator/s%5Cleft(t%5Cright)%3D2%5Cleft(m%2Bvt%2B%5Cfrac%7B1%7D%7B2%7Dat%5E%7B2%7D%5Cright)%2C%20t%3D%5Cfrac%7B-v%7D%7Ba%7D
 	double lookaheadDist = MAX(50.0, minDist - pow(egoV, 2) / maxDeceleration);  // (m)
 
-	// The entities with the smallest ds are coming first, this is important for cut-out scenario
-	// In case of cut-out scenario it is crucial to detect first the cut-out vehicle and afterwards to check if the next vehicle
-	// in front of cut-out vehicle is at TTC < 2sec.
-	for (int i = static_cast<int>(entities_->object_.size()) - 1; i >= 0; i--)
+	for (size_t i = 0; i < entities_->object_.size(); i++)
 	{
 		if (entities_->object_[i] == object_)
 		{
@@ -125,8 +125,8 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 					// cut-in would be in the red zone in front of ego vehicle after lane change
 					// TTC (<= 2sec) + offset (> 0.375) + perception time (0.4sec, see plot of regulation)
 					waitTime_ = 1.15;  // 0.75sec braking delay + 0.4sec risk perception time (distance a and b in plot of regulation)
-					ALKS_LOG("ECE ALKS driver -> cut-in detected (TTC: %.2f) -> start braking after %.2f sec (braking delay + risk perception time)",
-						TTC, waitTime_);
+					ALKS_LOG("ECE ALKS driver -> cut-in detected of '%s' (TTC: %.2f) -> driver starts braking after %.2f sec (braking delay + risk perception time)",
+						entities_->object_[i]->name_, TTC, waitTime_);
 					driverBraking_ = true;
 				}
 			}
@@ -139,9 +139,26 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 					// relative heading angles are playing no role for reference driver
 					if (dtFreeCutOut_ == -LARGE_NUMBER)
 					{
-						ALKS_LOG("ECE ALKS driver -> cut-out detected");
+						ALKS_LOG("ECE ALKS driver -> cut-out detected of '%s'", entities_->object_[i]->name_);
+						if (!driverBrakeCandidateName.empty())
+						{
+							waitTime_ = 1.15;  // 0.75sec braking delay + 0.4sec risk perception time (distance a and b in plot of regulation)
+							ALKS_LOG("ECE ALKS driver -> cut-out '%s' and next vehicle in front '%s' detected (TTC: %.2f) -> "
+								"start braking after %.2f sec (braking delay + risk perception time)", entities_->object_[i]->name_,
+								driverBrakeCandidateName, TTC, waitTime_);
+							driverBraking_ = true;
+						}
+						driverBrakeCandidateName = entities_->object_[i]->name_;
 					}
 					dtFreeCutOut_ = fabs(diff.dt) - 0.5 * (egoW + targetW);
+					if (!aebBrakeCandidateName.empty() && dtFreeCutOut_ >= 0)
+					{
+						ALKS_LOG("ECE ALKS AEB -> full wrap of '%s' and '%s' (TTC: %.2f) -> AEB starts braking", object_->name_, aebBrakeCandidateName,
+							aebBrakeCandidateTTC);
+						// AEB brakes harder than driver, no need to continue checking for scenario if aeb is already braking
+						aebBraking_ = true;
+						break;
+					}
 				}
 
 				// relative heading angles are playing no role for reference driver
@@ -156,13 +173,13 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 						if (targetAS < -5)
 						{
 							waitTime_ += 0.4;  // + 0.4sec risk perception time which begins when leading vehicle exceeds a deceleration of 5m/s2
-							ALKS_LOG("ECE ALKS driver -> deceleration detected (as: %.2f, TTC: %.2f) -> start braking after %.2f sec (braking delay + risk perception time)",
-								fabs(targetAS), TTC, waitTime_);
+							ALKS_LOG("ECE ALKS driver -> deceleration detected of '%s' (as: %.2f, TTC: %.2f) -> driver starts braking after %.2f sec "
+								"(braking delay + risk perception time)", entities_->object_[i]->name_, fabs(targetAS), TTC, waitTime_);
 						}
 						else
 						{
-							LOG("ECE ALKS driver -> deceleration detected (as: %.2f, TTC: %.2f) -> start braking after %.2f sec (braking delay, no risk perception time)",
-								fabs(targetAS), TTC, waitTime_);
+							LOG("ECE ALKS driver -> deceleration detected of '%s' (as: %.2f, TTC: %.2f) -> driver starts braking after %.2f sec "
+								"(braking delay, no risk perception time)", entities_->object_[i]->name_, fabs(targetAS), TTC, waitTime_);
 						}
 						driverBraking_ = true;
 					}
@@ -174,7 +191,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 					// Thus one can directly brake with AEB
 					if (fabs(diff.dt) < SMALL_NUMBER)
 					{
-						ALKS_LOG("ECE ALKS AEB -> full wrap of ego and target (TTC: %.2f) -> start braking", TTC);
+						ALKS_LOG("ECE ALKS AEB -> full wrap of '%s' and '%s' (TTC: %.2f) -> AEB starts braking", object_->name_, entities_->object_[i]->name_, TTC);
 						aebBraking_ = true;
 						// AEB brakes harder than driver, no need to continue checking for scenario if aeb is already braking
 						break;
@@ -187,21 +204,40 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 					if (fabs(diff.dt) < SMALL_NUMBER && (dtFreeCutOut_ >= 0 || dtFreeCutOut_ == -LARGE_NUMBER) &&
 						targetV < egoV && dsFree >= 0 && TTC <= 2)
 					{
-						ALKS_LOG("ECE ALKS AEB -> full wrap of ego and target (TTC: %.2f) -> start braking", TTC);
-						aebBraking_ = true;
-						// AEB brakes harder than driver, no need to continue checking for scenario if aeb is already braking
-						break;
+						// cut-out scenario or cut-in scenario have already been detected before
+						if (dtFreeCutOut_ >= 0 || driverBraking_)
+						{
+							ALKS_LOG("ECE ALKS AEB -> full wrap of '%s' and '%s' (TTC: %.2f) -> AEB starts braking", object_->name_, entities_->object_[i]->name_, TTC);
+							// AEB brakes harder than driver, no need to continue checking for scenario if aeb is already braking
+							aebBraking_ = true;
+							break;
+						}
+						else
+						{
+							// There is the possibility of cut-out scenario and that the cut-out vehicle was not examined before this vehicle,
+							// which should be in front of cut-out vehicle. But there is also the possibility that there is no cut-out scenario happening.
+							aebBrakeCandidateName = entities_->object_[i]->name_;
+							aebBrakeCandidateTTC = TTC;
+						}
 					}
 
 					// There was a cut-out detected of another vehicle between this vehicle and ego
 					// TTC between ego and object in front of cut-out object <= 2sec
 					// Thus this vehicle (in front of cut-out vehicle) is in the red zone in the plot of regulation
-					if (!driverBraking_ && dtFreeCutOut_ > -LARGE_NUMBER && dsFree >= 0 && dsFree / fabs(egoV - targetV) <= 2)
+					if (!driverBraking_ && dsFree >= 0 && TTC <= 2)
 					{
-						waitTime_ = 1.15;  // 0.75sec braking delay + 0.4sec risk perception time (distance a and b in plot of regulation)
-						ALKS_LOG("ECE ALKS driver -> cut-out and next vehicle in front detected (TTC: %.2f) -> "
-							"start braking after %.2f sec (braking delay + risk perception time)", TTC, waitTime_);
-						driverBraking_ = true;
+						if (dtFreeCutOut_ > -LARGE_NUMBER)
+						{
+							waitTime_ = 1.15;  // 0.75sec braking delay + 0.4sec risk perception time (distance a and b in plot of regulation)
+							ALKS_LOG("ECE ALKS driver -> cut-out '%s' and next vehicle in front '%s' detected (TTC: %.2f) -> "
+								"driver starts braking after %.2f sec (braking delay + risk perception time)", driverBrakeCandidateName, entities_->object_[i]->name_,
+								TTC, waitTime_);
+							driverBraking_ = true;
+						}
+						else
+						{
+							driverBrakeCandidateName = entities_->object_[i]->name_;
+						}
 					}
 				}
 			}
@@ -225,7 +261,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 			// MAX comparing to 0, because it makes no sense to drive backwards
 			acc = timeSinceBraking_ / 0.6 * 0.85;
 			currentSpeed_ = MAX(0, egoV - acc * 9.81 * timeStep);
-			ALKS_LOG("ECE ALKS AEB -> braking from %.2f to %.2f (acc: %.3fG)", egoV, currentSpeed_, MIN(acc, egoV / timeStep / 9.81));
+			ALKS_LOG("ECE ALKS AEB -> '%s' braking from %.2f to %.2f (acc: %.3fG)", object_->name_, egoV, currentSpeed_, MIN(acc, egoV / timeStep / 9.81));
 		}
 		// now the reference driver would brake
 		else if (driverBraking_)
@@ -238,7 +274,8 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 				// MAX comparing to 0, because it makes no sense to drive backwards
 				acc = timeSinceBraking_ / 0.6 * 0.774;
 				currentSpeed_ = MAX(0, egoV - acc * 9.81 * timeStep);
-				ALKS_LOG("ECE ALKS driver -> wait time passed -> braking from %.2f to %.2f (acc: %.3fG)", egoV, currentSpeed_, MIN(acc, egoV / timeStep / 9.81));
+				ALKS_LOG("ECE ALKS driver -> wait time passed -> '%s' braking from %.2f to %.2f (acc: %.3fG)", object_->name_, egoV,
+					currentSpeed_, MIN(acc, egoV / timeStep / 9.81));
 			}
 			waitTime_ = MAX(0.0, waitTime_ - timeStep);  // reduce waitTime by current timeStep each time this if branch is called
 		}

--- a/EnvironmentSimulator/Modules/Controllers/ControllerECE_ALKS_DRIVER.cpp
+++ b/EnvironmentSimulator/Modules/Controllers/ControllerECE_ALKS_DRIVER.cpp
@@ -145,7 +145,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 							waitTime_ = 1.15;  // 0.75sec braking delay + 0.4sec risk perception time (distance a and b in plot of regulation)
 							ALKS_LOG("ECE ALKS driver -> cut-out '%s' and next vehicle in front '%s' detected (TTC: %.2f) -> "
 								"start braking after %.2f sec (braking delay + risk perception time)", entities_->object_[i]->name_.c_str(),
-								driverBrakeCandidateName, TTC, waitTime_);
+								driverBrakeCandidateName.c_str(), TTC, waitTime_);
 							driverBraking_ = true;
 						}
 						driverBrakeCandidateName = entities_->object_[i]->name_;
@@ -153,7 +153,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 					dtFreeCutOut_ = fabs(diff.dt) - 0.5 * (egoW + targetW);
 					if (!aebBrakeCandidateName.empty() && dtFreeCutOut_ >= 0)
 					{
-						ALKS_LOG("ECE ALKS AEB -> full wrap of '%s' and '%s' (TTC: %.2f) -> AEB starts braking", object_->name_.c_str(), aebBrakeCandidateName,
+						ALKS_LOG("ECE ALKS AEB -> full wrap of '%s' and '%s' (TTC: %.2f) -> AEB starts braking", object_->name_.c_str(), aebBrakeCandidateName.c_str(),
 							aebBrakeCandidateTTC);
 						// AEB brakes harder than driver, no need to continue checking for scenario if aeb is already braking
 						aebBraking_ = true;
@@ -230,7 +230,7 @@ void ControllerECE_ALKS_DRIVER::Step(double timeStep)
 						{
 							waitTime_ = 1.15;  // 0.75sec braking delay + 0.4sec risk perception time (distance a and b in plot of regulation)
 							ALKS_LOG("ECE ALKS driver -> cut-out '%s' and next vehicle in front '%s' detected (TTC: %.2f) -> "
-								"driver starts braking after %.2f sec (braking delay + risk perception time)", driverBrakeCandidateName, entities_->object_[i]->name_.c_str(),
+								"driver starts braking after %.2f sec (braking delay + risk perception time)", driverBrakeCandidateName.c_str(), entities_->object_[i]->name_.c_str(),
 								TTC, waitTime_);
 							driverBraking_ = true;
 						}


### PR DESCRIPTION
The list of entities can be unsorted, thus the conditions were modified, that a cut-out can be detected even if the cut-out vehicle

is checked after the next vehicle in front of it was already checked (save its name and its TTC).
Names of vehicles were added to log messages.

Maybe not an important change for the funcionality of the driver model at all, because in most situations the cut-out vehicle was detected in time first (long) before the next vehicle in front is at TTC < 2sec. If the new implemented case would happen, then the both vehicles in front of ego would have a crash before cut-out is happening and this case must be seperately handled by the user (see in regulation plot grey dots (wording 'leading vehicles collision'). This means that in such a case it plays no role how the ego driver is behaving or reacting.