### PR TITLE
Fix - AcquirePositionAction

### DIFF
--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * esmini - Environment Simulator Minimalistic
  * https://github.com/esmini/esmini
  *
@@ -10016,7 +10016,15 @@ int Route::AddWaypoint(Position* position)
 				{
 					// Find out lane ID of the connecting road
 					Position connected_pos = Position(nodes[i - 1]->fromRoad->GetId(), nodes[i - 1]->fromLaneId, 0, 0);
-					all_waypoints_.push_back(*position);
+					if (connected_pos.GetLaneId() < 0)
+					{
+						connected_pos.SetHeadingRelative(0.0);
+					}
+					else
+					{
+						connected_pos.SetHeadingRelative(M_PI);
+					}
+					all_waypoints_.push_back(connected_pos);
 					minimal_waypoints_.push_back(connected_pos);
 					LOG("Route::AddWaypoint Added intermediate waypoint %d roadId %d laneId %d",
 						(int)minimal_waypoints_.size() - 1, connected_pos.GetTrackId(), nodes[i - 1]->fromLaneId);
@@ -10394,23 +10402,17 @@ int Route::GetWayPointDirection(int index)
 			return -1 * direction;
 		}
 	}
+
+	// At first and only (minimal) waypoint, so try to find another waypoint for direction
+	if (all_waypoints_.size() > 1 && (road->GetId() == all_waypoints_[1].GetTrackId()))
+	{
+		return direction;
+	}
 	else
 	{
-		// At first and only (minimal) waypoint, so try to find another waypoint for direction
-		if (all_waypoints_.size() > 1 && (road->GetId() == all_waypoints_[1].GetTrackId()))
-		{
-			return direction;
-		}
-		else
-		{
-			LOG("Only one waypoint, no direction");
-			return 0;
-		}
+		LOG("Only one waypoint, no direction");
+		return 0;
 	}
-
-	LOG("Unexpected case, failed to find out direction of route (from road id %d)", road->GetId());
-
-	return direction;
 }
 
 void Route::setName(std::string name)

--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.hpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.hpp
@@ -2458,7 +2458,6 @@ namespace roadmanager
 		int GetTrackId() { return currentPos_.GetTrackId(); }
 		Position* GetWaypoint(int index = -1);  // -1 means current
 		Road* GetRoadAtOtherEndOfConnectingRoad(Road* incoming_road);
-		int GetDirectionRelativeRoad();
 		Position* GetCurrentPosition() { return &currentPos_; }
 
 		/**


### PR DESCRIPTION
Hi Emil,
we were observing some problems using the AcquirePositionAction lately, in particular, if the target position was on the same road(ID) as the initial position. In that case, the vehicle was either freezing at the end of the road or teleporting back to its start.
Also, for some TargetPositions the routing never stopped (even though the vehicle passed the target position), because the sign of the route direction was not determined correctly. Those cases are easily reconstructed using simple AcquirePositionActions on the aforementioned Town01.xodr. If necessary, I can also upload example XOSCs.

This commit should fix the aforementioned issues (related to determining route direction), via
- Usage of another waypoint from all_waypoints_ when there is only one minimal waypoint
- Comparison of PI/2 < heading < 3*PI/2 (instead of 3*PI/4 on the right hand side) to determine the (heading-based) direction
- Returning the heading-based direction as the default (which is necessary to properly keep track of how far on the route a vehicle has already moved)
- Warning if route direction and heading direction are not aligned

Please have a look whether I missed anything or broke some other functionality by accident.

Thanks in advance,
Christoph