### PR TITLE
Fix - linear LaneOffset Action should properly use the given rate

### DIFF
--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
@@ -117,9 +117,8 @@ double OSCPrivateAction::TransitionDynamics::GetTargetParamValByPrimPrimPeak(dou
 	}
 	else if (shape_ == DynamicsShape::LINEAR)
 	{
-		// Acceleration is infinite at start and end, anything else should result in flat line
-		// Just to have something reasonable, re-use acc equation from CUBIC case
-		return sqrt(6 * abs(GetTargetVal() - GetStartVal()) / prim_prim_peak);
+		// For the linear case, the duration should be distance / rate.
+		return abs(GetTargetVal() - GetStartVal()) / prim_prim_peak;
 	}
 	else if (shape_ == DynamicsShape::SINUSOIDAL)
 	{


### PR DESCRIPTION
Hi Emil,

yet another pull request - hoping that our change finds your approval and is in line with the OpenSCENARIO standard.

Using a "linear" LaneOffset action we were wondering that esmini calculated other durations for the respective maneuvers than we would have expected. For example, for a vehicle starting in the lane center and targeting an absolute lane offset of 1m, we would have expected the maneuver to take 2 seconds when giving it a rate of 0.5 (=what we understand as linear behavior).

Looking at the current esmini-code, we revisited the standard but still understand that the given parameter for the LaneOffsetAction should be used as the rate of the linear transition, which is achieved by the suggested change.