### PR TITLE
Suggestion: new esminiLib-Method to register a callback for triggered conditions

### DIFF
--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -22,6 +22,7 @@
 #endif
 #include "vehicle.hpp"
 #include "pugixml.hpp"
+#include "OSCCondition.hpp"
 
 using namespace scenarioengine;
 
@@ -80,6 +81,9 @@ static void resetScenario(void)
 		argc_ = 0;
 	}
 	args_v.clear();
+	
+	// Reset (global) condition callback
+	OSCCondition::conditionCallback = nullptr;
 }
 
 static void AddArgument(const char *str, bool split = true)
@@ -1662,6 +1666,11 @@ extern "C"
 		cb.func = fnPtr;
 		objCallback.push_back(cb);
 		player->RegisterObjCallback(object_id, objCallbackFn, user_data);
+	}
+
+	SE_DLL_API void SE_RegisterConditionCallback(void (*fnPtr)(const char* name, double timestamp))
+	{
+		OSCCondition::conditionCallback = fnPtr;
 	}
 
 	SE_DLL_API int SE_GetNumberOfRoadSigns(int road_id)

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -23,6 +23,7 @@
 #include "vehicle.hpp"
 #include "pugixml.hpp"
 #include "OSCCondition.hpp"
+#include "OSCManeuver.hpp"
 
 using namespace scenarioengine;
 
@@ -1671,6 +1672,11 @@ extern "C"
 	SE_DLL_API void SE_RegisterConditionCallback(void (*fnPtr)(const char* name, double timestamp))
 	{
 		OSCCondition::conditionCallback = fnPtr;
+	}
+
+	SE_DLL_API void SE_RegisterEventCallback(void (*fnPtr)(const char* name, double timestamp, bool start))
+	{
+		Event::eventCallback = fnPtr;
 	}
 
 	SE_DLL_API int SE_GetNumberOfRoadSigns(int road_id)

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -808,6 +808,14 @@ extern "C"
 	SE_DLL_API void SE_RegisterObjectCallback(int object_id, void (*fnPtr)(SE_ScenarioObjectState *, void *), void *user_data);
 
 	/**
+	Registers a function to be called back from esmini every time a condition is triggered.
+	The name of the respective condition and the current timestamp will be returned.
+	Registered callbacks will be cleared between SE_Init calls.
+	@param fnPtr A pointer to the function to be invoked
+	*/
+	SE_DLL_API void SE_RegisterConditionCallback(void (*fnPtr)(const char* name, double timestamp));
+
+	/**
 		Get the number of road signs along specified road
 		@param road_id The road along which to look for signs
 		@return Number of road signs

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -816,6 +816,16 @@ extern "C"
 	SE_DLL_API void SE_RegisterConditionCallback(void (*fnPtr)(const char* name, double timestamp));
 
 	/**
+	Registers a function to be called back from esmini every time an event starts or ends.
+	The name of the respective event, the current timestamp and whether the event
+	starts (true) or ends (false) will be returned.
+	In case an event starts and ends within the same simulation step, only the end-transition may occur.
+	Registered callbacks will be cleared between SE_Init calls.
+	@param fnPtr A pointer to the function to be invoked
+	*/
+	SE_DLL_API void SE_RegisterEventCallback(void (*fnPtr)(const char* name, double timestamp, bool start));
+
+	/**
 		Get the number of road signs along specified road
 		@param road_id The road along which to look for signs
 		@return Number of road signs

--- a/EnvironmentSimulator/Modules/Controllers/ControllerRel2Abs.cpp
+++ b/EnvironmentSimulator/Modules/Controllers/ControllerRel2Abs.cpp
@@ -409,7 +409,7 @@ void ControllerRel2Abs::Step(double timeStep)
 							}
 						}
 					}
-					lda->End();
+					lda->End(scenarioEngine_->getSimulationTime());
 					lsa->Start(scenarioEngine_->getSimulationTime(),timeStep);
 					LOG("Replacing the relative target LongDistanceAction with an absolute target LongSpeedAction and target value: %lf", currentSpeed);
 				}
@@ -518,7 +518,7 @@ void ControllerRel2Abs::Step(double timeStep)
 									}
 								}
 							}
-							sa->End();
+							sa->End(scenarioEngine_->getSimulationTime());
 							lsa->Start(scenarioEngine_->getSimulationTime(), timeStep);
 							LOG("Replacing the SynchronizeAction (with final speed) with an absolute target LongSpeedAction and target value: %lf", trgSpeed);
 						}
@@ -563,7 +563,7 @@ void ControllerRel2Abs::Step(double timeStep)
 								}
 							}
 						}
-						sa->End();
+						sa->End(scenarioEngine_->getSimulationTime());
 						lsa->Start(scenarioEngine_->getSimulationTime(), timeStep);
 						LOG("Replacing the SynchronizeAction (no final speed) with an absolute target LongSpeedAction and target value: %lf", currentSpeed);
 					}

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCAction.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCAction.hpp
@@ -119,7 +119,7 @@ namespace scenarioengine
 			}
 		}
 
-		virtual void End()
+		virtual void End(double simTime)
 		{
 			// Allow elements to move directly from standby to complete
 			// Some actions are atomic, and don't need run time

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCCondition.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCCondition.cpp
@@ -16,6 +16,8 @@
 using namespace scenarioengine;
 using namespace roadmanager;
 
+void (*OSCCondition::conditionCallback)(const char* name, double timestamp) = nullptr;
+
 std::string Rule2Str(Rule rule)
 {
 	if (rule == Rule::GREATER_THAN)
@@ -269,6 +271,13 @@ bool OSCCondition::Evaluate(StoryBoard *storyBoard, double sim_time)
 			LOG("%s timer expired at %.2f seconds", name_.c_str(), timer_.Elapsed(sim_time));
 			timer_.Reset();
 			state_ = ConditionState::TRIGGERED;
+
+			// Trigger the global condition callback
+			if (conditionCallback != nullptr)
+			{
+				conditionCallback(name_.c_str(), sim_time);
+			}
+
 			return true;
 		}
 		else
@@ -297,6 +306,12 @@ bool OSCCondition::Evaluate(StoryBoard *storyBoard, double sim_time)
 	if (trig)
 	{
 		state_ = ConditionState::TRIGGERED;
+
+		// Trigger the global condition callback
+		if (conditionCallback != nullptr)
+		{
+			conditionCallback(name_.c_str(), sim_time);
+		}
 	}
 
 	return trig;

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCCondition.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCCondition.hpp
@@ -31,6 +31,7 @@ namespace scenarioengine
 	class OSCCondition
 	{
 	public:
+		static void (*conditionCallback)(const char* name, double timestamp);
 
 		enum class ConditionState
 		{

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCManeuver.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCManeuver.hpp
@@ -27,6 +27,7 @@ namespace scenarioengine
 	class Event: public StoryBoardElement
 	{
 	public:
+		static void (*eventCallback)(const char* name, double timestamp, bool start);
 
 		typedef enum
 		{
@@ -45,7 +46,7 @@ namespace scenarioengine
 		Event() : start_trigger_(0), StoryBoardElement(StoryBoardElement::ElementType::EVENT) {}
 
 		void Start(double simTime, double dt);
-		void End();
+		void End(double simTime);
 		void Stop();
 
 		void UpdateState();

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
@@ -289,9 +289,9 @@ void AssignRouteAction::Start(double simTime, double dt)
 	}
 }
 
-void AssignRouteAction::Step(double, double)
+void AssignRouteAction::Step(double simTime, double dt)
 {
-	OSCAction::End();
+	OSCAction::End(simTime);
 }
 
 void AssignRouteAction::ReplaceObjectRefs(Object* obj1, Object* obj2)
@@ -334,9 +334,9 @@ void FollowTrajectoryAction::Start(double simTime, double dt)
 	object_->SetDirtyBits(Object::DirtyBit::LATERAL | Object::DirtyBit::LONGITUDINAL);
 }
 
-void FollowTrajectoryAction::End()
+void FollowTrajectoryAction::End(double simTime)
 {
-	OSCAction::End();
+	OSCAction::End(simTime);
 
 	if (object_->GetControllerMode() == Controller::Mode::MODE_OVERRIDE &&
 		object_->IsControllerActiveOnDomains(ControlDomains::DOMAIN_LAT))
@@ -442,7 +442,7 @@ void FollowTrajectoryAction::Step(double simTime, double dt)
 
 		object_->pos_.SetInertiaPos(object_->pos_.GetX() + dx, object_->pos_.GetY() + dy, object_->pos_.GetH());
 
-		End();
+		End(simTime);
 	}
 }
 
@@ -490,9 +490,9 @@ void AcquirePositionAction::Start(double simTime, double dt)
 	}
 }
 
-void AcquirePositionAction::Step(double, double)
+void AcquirePositionAction::Step(double simTime, double dt)
 {
-	OSCAction::End();
+	OSCAction::End(simTime);
 }
 
 void AcquirePositionAction::ReplaceObjectRefs(Object* obj1, Object* obj2)
@@ -658,7 +658,7 @@ void LatLaneChangeAction::Step(double simTime, double dt)
 		// Passed target value?
 		transition_.GetParamVal() > 0 && SIGN(offset_agnostic - transition_.GetTargetVal()) != SIGN(transition_.GetStartVal() - transition_.GetTargetVal()))
 	{
-		OSCAction::End();
+		OSCAction::End(simTime);
 		object_->pos_.SetHeadingRelativeRoadDirection(0);
 	}
 	else
@@ -761,7 +761,7 @@ void LatLaneOffsetAction::Step(double simTime, double dt)
 		// Passed target value?
 		transition_.GetParamVal() > 0 && SIGN(offset_agnostic - transition_.GetTargetVal()) != SIGN(transition_.GetStartVal() - transition_.GetTargetVal()))
 	{
-		OSCAction::End();
+		OSCAction::End(simTime);
 		object_->pos_.SetLanePos(object_->pos_.GetTrackId(), object_->pos_.GetLaneId(), object_->pos_.GetS(), SIGN(object_->pos_.GetLaneId()) * transition_.GetTargetVal());
 		object_->pos_.SetHeadingRelativeRoadDirection(0);
 	}
@@ -835,7 +835,7 @@ void LongSpeedAction::Start(double simTime, double dt)
 		object_->IsControllerActiveOnDomains(ControlDomains::DOMAIN_LONG))
 	{
 		// longitudinal motion controlled elsewhere
-		OSCAction::End();
+		OSCAction::End(simTime);
 		return;
 	}
 
@@ -862,7 +862,7 @@ void LongSpeedAction::Step(double simTime, double dt)
 		object_->IsControllerActiveOnDomains(ControlDomains::DOMAIN_LONG))
 	{
 		// longitudinal motion controlled elsewhere
-		OSCAction::End();
+		OSCAction::End(simTime);
 		return;
 	}
 
@@ -910,7 +910,7 @@ void LongSpeedAction::Step(double simTime, double dt)
 
 	if (target_speed_reached_ && !(target_->type_ == Target::TargetType::RELATIVE_SPEED && ((TargetRelative*)target_)->continuous_ == true))
 	{
-		OSCAction::End();
+		OSCAction::End(simTime);
 	}
 }
 
@@ -1033,7 +1033,7 @@ void LongDistanceAction::Step(double simTime, double)
 	if (continuous_ == false && fabs(distance_diff) < LONGITUDINAL_DISTANCE_THRESHOLD)
 	{
 		// Reached requested distance, quit action
-		OSCAction::End();
+		OSCAction::End(simTime);
 	}
 
 	if (dynamics_.none_ == true)
@@ -1118,9 +1118,9 @@ void TeleportAction::Start(double simTime, double dt)
 	object_->reset_ = true;
 }
 
-void TeleportAction::Step(double, double)
+void TeleportAction::Step(double simTime, double dt)
 {
-	OSCAction::End();
+	OSCAction::End(simTime);
 }
 
 void TeleportAction::ReplaceObjectRefs(Object* obj1, Object* obj2)
@@ -1309,7 +1309,7 @@ void SynchronizeAction::Step(double simTime, double)
 
 	if (done)
 	{
-		OSCAction::End();
+		OSCAction::End(simTime);
 	}
 	else
 	{
@@ -1609,9 +1609,9 @@ void VisibilityAction::Start(double simTime, double dt)
 	);
 }
 
-void VisibilityAction::Step(double, double)
+void VisibilityAction::Step(double simTime, double dt)
 {
-	OSCAction::End();
+	OSCAction::End(simTime);
 }
 
 int OverrideControlAction::AddOverrideStatus(Object::OverrideActionStatus status)
@@ -1661,7 +1661,7 @@ void OverrideControlAction::Start(double simTime, double dt)
 
 void OverrideControlAction::Step(double simTime, double dt)
 {
-	OSCAction::End();
+	OSCAction::End(simTime);
 }
 
 double OverrideControlAction::RangeCheckAndErrorLog(Object::OverrideType type, double valueCheck, double lowerLimit, double upperLimit, bool ifRound)

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.hpp
@@ -689,7 +689,7 @@ namespace scenarioengine
 
 		void Step(double simTime, double dt);
 		void Start(double simTime, double dt);
-		void End();
+		void End(double simTime);
 
 		void ReplaceObjectRefs(Object* obj1, Object* obj2);
 	};
@@ -820,7 +820,7 @@ namespace scenarioengine
 
 		void Step(double, double) {}
 
-		void End()
+		void End(double simTime)
 		{
 			if (object_->GetActivatedControllerType() != 0 && object_->controller_ != nullptr)
 			{
@@ -828,7 +828,7 @@ namespace scenarioengine
 			}
 			// Make sure heading is aligned with road driving direction
 			object_->pos_.SetHeadingRelative((object_->pos_.GetHRelative() > M_PI_2 && object_->pos_.GetHRelative() < 3 * M_PI_2) ? M_PI : 0.0);
-			OSCAction::End();
+			OSCAction::End(simTime);
 		}
 	};
 

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
@@ -283,7 +283,7 @@ int ScenarioEngine::step(double deltaSimTime)
 			{
 				if (act->stop_trigger_->Evaluate(&storyBoard, simulationTime_) == true)
 				{
-					act->End();
+					act->End(simulationTime_);
 				}
 			}
 
@@ -360,7 +360,7 @@ int ScenarioEngine::step(double deltaSimTime)
 														}
 													}
 
-													maneuver->event_[n]->End();
+													maneuver->event_[n]->End(simulationTime_);
 													LOG("Event %s ended, overwritten by event %s",
 														maneuver->event_[n]->name_.c_str(), event->name_.c_str());
 												}
@@ -469,7 +469,7 @@ int ScenarioEngine::step(double deltaSimTime)
 									}
 
 									// Actions done -> Set event done
-									event->End();
+									event->End(simulationTime_);
 								}
 							}
 						}


### PR DESCRIPTION
Hi Emil,

and another one - but this time it is not a fix, but a suggestion for a new feature.

UseCase: We would like to know from a simulation run in esmini when a certain condition was triggered. Of course, it would be possible to parse the log/console output, but a much cleaner solution seems to be registering a callback that is called every time a condition is triggered.

What do you think?

Feel free to ask further questions, request changes or make suggestions - we want to make this an improvement of esmini and not just a function we "need".