### PR TITLE
Fixed issue in RoadPath::Calculate

### DIFF
--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -4510,7 +4510,7 @@ int RoadPath::Calculate(double &dist, bool bothDirections, double maxDist)
 					if ((node->link == startRoad->GetLink(LinkType::PREDECESSOR) &&
 						abs(startPos_->GetHRelative()) > M_PI_2 && abs(startPos_->GetHRelative()) < 3 * M_PI / 2) ||
 						((node->link == startRoad->GetLink(LinkType::SUCCESSOR) &&
-						abs(startPos_->GetHRelative()) < M_PI_2 || abs(startPos_->GetHRelative()) > 3 * M_PI / 2)))
+						(abs(startPos_->GetHRelative()) < M_PI_2 || abs(startPos_->GetHRelative()) > 3 * M_PI / 2))))
 					{
 						direction_ = 1;
 					}

--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -4507,10 +4507,15 @@ int RoadPath::Calculate(double &dist, bool bothDirections, double maxDist)
 				if (node->previous == 0)
 				{
 					// This is the first node - inspect whether it is in front or behind start position
-					if ((node->link == startRoad->GetLink(LinkType::PREDECESSOR) &&
-						abs(startPos_->GetHRelative()) > M_PI_2 && abs(startPos_->GetHRelative()) < 3 * M_PI / 2) ||
-						((node->link == startRoad->GetLink(LinkType::SUCCESSOR) &&
-						(abs(startPos_->GetHRelative()) < M_PI_2 || abs(startPos_->GetHRelative()) > 3 * M_PI / 2))))
+					bool isPred = node->link == startRoad->GetLink(LinkType::PREDECESSOR);
+					bool isGTPi2 = abs(startPos_->GetHRelative()) > M_PI_2;
+					bool isLT3Pi2 = abs(startPos_->GetHRelative()) < 3 * M_PI / 2;
+					bool isSucc = node->link == startRoad->GetLink(LinkType::SUCCESSOR);
+					bool isLTPi2 = !isGTPi2;
+					bool isGT3Pi2 = !isLT3Pi2;
+					bool isPredAndBack = isPred && isGTPi2 && isLT3Pi2;
+					bool isSuccAndFront = isSucc && (isLTPi2 || isGT3Pi2);
+					if (isPredAndBack || isSuccAndFront)
 					{
 						direction_ = 1;
 					}


### PR DESCRIPTION
Hi Emil, it's me again

A colleague and I tracked down an issue, still related to `Position::Delta`. This time, we sometimes had a `ds` with the wrong sign. Our investigation lead us there:

https://github.com/esmini/esmini/blob/45ef22ed04867f6e6630bb73461e5d4a3fcd7d93/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp#L4510-L4520

We were in the first cast of the `OR` (`node->link == startRoad->GetLink(LinkType::PREDECESSOR)`), and our `HRelative` was like 2*PI, so we fully expected the condition to be false, to have `direction_` set to `-1` and then to have proper signing on our `ds`.

However, the second part of the `OR` seems to be missing a set of parenthesis, which meant the condition was evaluated as `A AND B OR C` instead of what we're assuming should be `A AND (B OR C)`.

In our case, A was obviously false, but C was true. And apparently, in C++, `false && false || true` is `true`, so we got in the condition, `direction_` was set to `1`, which lead to our problem.

We fixed that pretty hastily by just adding parenthesis, but I think we should have taken this opportunity to rewrite this condition more clearly, which makes it both more readable and help reduce the risk of mistakes. Something like the following

```cpp
bool isPred = node->link == startRoad->GetLink(LinkType::PREDECESSOR);
bool isGTPi2 = abs(startPos_->GetHRelative()) > M_PI_2;
bool isLT3Pi2 = abs(startPos_->GetHRelative()) < 3 * M_PI / 2);
bool isSucc = node->link == startRoad->GetLink(LinkType::SUCCESSOR);
bool isLTPi2 = abs(startPos_->GetHRelative()) < M_PI_2;
bool isGT3Pi2 = abs(startPos_->GetHRelative()) > 3 * M_PI / 2;
if ((isPred && isGTPi2  && isLT3Pi2) || (isSucc && (isLTPi2  || isGT3Pi2 ))) {
    // ...
}

// or

bool isPredAndBack = isPred && isGTPi2  && isLT3Pi2;
bool isSuccAndFront = isSucc && (isLTPi2  || isGT3Pi2 );

if (isPredAndBack || isSuccAndFront) {
    // ...
}

```

The compiler will optimize all that anyway, so it should have no performance impact.