### PR TITLE
Fix - reset event callback in resetScenario

### DIFF
--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -86,8 +86,10 @@ static void resetScenario(void)
 	}
 	args_v.clear();
 
-	// Reset (global) condition callback
+	// Reset (global) callbacks
 	OSCCondition::conditionCallback = nullptr;
+	Event::eventCallback = nullptr;
+
 	time_stamp = 0;
 }
 


### PR DESCRIPTION
Hi Emil,

unfortunately our initial contribution was missing this line to reset the event callback.
If nothing is missing, please merge this.

Thanks!