### PR TITLE
[roadmngr] Fixed Delta sometimes returning wrong dt/dlane in junction

### DIFF
--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -8310,6 +8310,16 @@ bool Position::Delta(Position* pos_b, PositionDiff &diff, bool bothDirections, d
 			bool isPathBackward = firstNode->link->GetType() == LinkType::PREDECESSOR;
 			bool isConnectedToEnd = lastNode->link->GetContactPointType() == ContactPointType::CONTACT_POINT_END;
 			bool isConnectedToStart = lastNode->link->GetContactPointType() == ContactPointType::CONTACT_POINT_START;
+			bool isConnectedToJunction = lastNode->link->GetContactPointType() == ContactPointType::CONTACT_POINT_JUNCTION;
+			if (isConnectedToJunction) {
+				Road* lastNodeRoad = lastNode->fromRoad;
+				Road* lastRoad = GetRoadById(pos_b->GetTrackId());
+				RoadLink* linkPred = lastRoad->GetLink(LinkType::PREDECESSOR);
+				RoadLink* linkSucc = lastRoad->GetLink(LinkType::SUCCESSOR);
+				isConnectedToStart = linkPred && lastNodeRoad && lastNodeRoad->GetId() == linkPred->GetElementId();
+				isConnectedToEnd   = linkSucc && lastNodeRoad && lastNodeRoad->GetId() == linkSucc->GetElementId();
+			}
+
 			bool isHeadToHead = isPathForward && isConnectedToEnd;
 			bool isToeToToe = isPathBackward && isConnectedToStart;
 


### PR DESCRIPTION
Hi Emil,

This PR is somewhat related to #261 and #266, as it fixes some errors in `Position::Delta`. As usual, I brought my MSPaint skills to help illustrate the issue.

![image](https://user-images.githubusercontent.com/53508707/168257383-0018b89a-60d1-42eb-97b2-f6eaf3aa03c5.png)

I've also attached the `xodr` file [here](https://github.com/esmini/esmini/files/8685974/delta_junction.txt) (as `txt` because of GitHub restrictions), and the coordinates are as follow

```
A
  X=782.53093750
  Y=1645.91328125
  Road=677
  Lane=1
  S=8.09
  T=-0.517
B
  X=782.96906250
  Y=1656.29312500
  Road=18
  Lane=1
  S=2.141
  T=0
```

So if we call B.Detla(A), we have a `dLaneId` of 0, where we expected 2. The issue lies here:

https://github.com/esmini/esmini/blob/ab19cd2a7e97fc2157d21345d092b3dc078fe73d/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp#L8311-L8312

The roads (18 and 677) are directly connected through the junction (665), so resolving the path is quite straightforward. However, the `lastNode`'s link is the road to junction link, meaning its `ContactPointType` is `CONTACT_POINT_JUNCTION`. So both bools are false, and HeadToHead/ToeToToe checking can't proceed to flip the LaneID and T.

This PR (hopefully!) solves this issue by checking if the last contact point is a junction, and if so, checks the connection by looking at the target road's predecessor and successor. I've tested it on the failing test mentioned above, plus some other random locations on the network, and I encountered no issue. But I didn't do any thorough testing.