### PR TITLE
Fix Wrong successor selecting at junction

### DIFF
--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -7334,7 +7334,7 @@ Position::ReturnCode Position::MoveToConnectingRoad(RoadLink *road_link, Contact
 					if (connecting_road)
 					{
 						Road* outgoing_road = junction->GetRoadAtOtherEndOfConnectingRoad(connecting_road, road);
-						if (outgoing_road == outgoing_road_target)
+						if (outgoing_road == outgoing_road_target && connecting_road->GetId() == r->GetTrackId())
 						{
 							connection_idx = i;
 						}

--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -7326,6 +7326,7 @@ Position::ReturnCode Position::MoveToConnectingRoad(RoadLink *road_link, Contact
 
 				// Find next road in route
 				Road* outgoing_road_target = r->GetRoadAtOtherEndOfConnectingRoad(road);
+				int optimal_connection_idx = -1;
 				for (int i = 0; i < n_connections; i++)
 				{
 					LaneRoadLaneConnection lane_road_lane_connection =
@@ -7334,11 +7335,17 @@ Position::ReturnCode Position::MoveToConnectingRoad(RoadLink *road_link, Contact
 					if (connecting_road)
 					{
 						Road* outgoing_road = junction->GetRoadAtOtherEndOfConnectingRoad(connecting_road, road);
-						if (outgoing_road == outgoing_road_target && connecting_road->GetId() == r->GetTrackId())
+						if (outgoing_road == outgoing_road_target)
 						{
 							connection_idx = i;
+							if (connecting_road->GetId() == r->GetTrackId()) {
+								optimal_connection_idx = connection_idx;
+							}
 						}
 					}
+				}
+				if (optimal_connection_idx != -1) {
+					connection_idx = optimal_connection_idx;
 				}
 			}
 			else if (junctionSelectorAngle >= 0.0)


### PR DESCRIPTION
This is a bugfix handling of a route tracking issue.

**Issue**
I drew a picture to illustrate an issue I met:
![junction](https://user-images.githubusercontent.com/13391983/174217633-83cd727b-9f3d-43db-b950-ba7a368af895.jpg)
On the assigned route, if the incoming road has more than 1 link at the junction that links to different lanes of the same outgoing road, it might select a wrong connecting road and finally go to the wrong target lane of the outgoing road.

**Example**
Here is an example of this issue:
![j](https://user-images.githubusercontent.com/13391983/174218966-aa46cb37-971e-4ab6-bfb8-41b7db39714c.png)
![issue](https://user-images.githubusercontent.com/13391983/174219129-20532795-840b-44eb-9025-baa4c8a74d3a.jpg)
The car was supposed to enter the rightmost lane as the routing waypoint specified, but it went to the wrong connecting road at the junction.

**Solution**
I think this road type commonly occurs in daily use, and it's not a map making issue. So I tried to find out the reason in esmini's code: When searching a connecting road at a junction, only outgoing road id is checked whether to be accordant with waypoint's road id. It doesn't consider that the outgoing road might have more than 1 accessible lane.

To solve that, it needs to check the lane id of the outgoing road with the lane id of the next waypoint, or check the connecting road id with the tracked road id. I chose the latter method because code modification is very simple.

**Test**
I tested the fixed code on the example: The car can go to the correct road now.
![fixed](https://user-images.githubusercontent.com/13391983/174222864-9286b625-7400-45b7-b1ac-9f2656214d9e.jpg)

Would you please take a look?