### PR TITLE
Removed SE_RegisterEventCallback, replaced the respective test 

### DIFF
--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -88,7 +88,6 @@ static void resetScenario(void)
 
 	// Reset (global) callbacks
 	OSCCondition::conditionCallback = nullptr;
-	Event::eventCallback = nullptr;
     StoryBoardElement::stateChangeCallback = nullptr;
 
 	time_stamp = 0;
@@ -1743,11 +1742,6 @@ extern "C"
     {
         StoryBoardElement::stateChangeCallback = fnPtr;
     }
-
-	SE_DLL_API void SE_RegisterEventCallback(void (*fnPtr)(const char* name, double timestamp, bool start))
-	{
-		Event::eventCallback = fnPtr;
-	}
 
 	SE_DLL_API int SE_GetNumberOfRoadSigns(int road_id)
 	{

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -896,16 +896,6 @@ extern "C"
     SE_DLL_API void SE_RegisterStoryBoardElementStateChangeCallback(void (*fnPtr)(const char* name, int type, int state));
 
 	/**
-	Registers a function to be called back from esmini every time an event starts or ends.
-	The name of the respective event, the current timestamp and whether the event
-	starts (true) or ends (false) will be returned.
-	In case an event starts and ends within the same simulation step, only the end-transition may occur.
-	Registered callbacks will be cleared between SE_Init calls.
-	@param fnPtr A pointer to the function to be invoked
-	*/
-	SE_DLL_API void SE_RegisterEventCallback(void (*fnPtr)(const char* name, double timestamp, bool start));
-
-	/**
 		Get the number of road signs along specified road
 		@param road_id The road along which to look for signs
 		@return Number of road signs

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCManeuver.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCManeuver.cpp
@@ -14,8 +14,6 @@
 
 using namespace scenarioengine;
 
-void (*Event::eventCallback)(const char* name, double timestamp, bool start) = nullptr;
-
 void Event::Start(double simTime, double dt)
 {
 	double adjustedTime = simTime;
@@ -87,11 +85,6 @@ void Event::Start(double simTime, double dt)
 		}
 	}
 
-	if (eventCallback != nullptr)
-	{
-		eventCallback(name_.c_str(), adjustedTime, true);
-	}
-
 	StoryBoardElement::Start(adjustedTime, dt);
 }
 
@@ -103,11 +96,6 @@ void Event::End(double simTime)
 		{
 			action_[i]->End(simTime);
 		}
-	}
-
-	if (eventCallback != nullptr)
-	{
-		eventCallback(name_.c_str(), simTime, false);
 	}
 
 	StoryBoardElement::End(simTime);

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCManeuver.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCManeuver.hpp
@@ -27,8 +27,6 @@ namespace scenarioengine
 	class Event: public StoryBoardElement
 	{
 	public:
-		static void (*eventCallback)(const char* name, double timestamp, bool start);
-
 		typedef enum
 		{
 			OVERWRITE,

--- a/EnvironmentSimulator/Unittest/ScenarioEngineDll_test.cpp
+++ b/EnvironmentSimulator/Unittest/ScenarioEngineDll_test.cpp
@@ -3292,15 +3292,14 @@ TEST(ReplayTest, TestMultiReplayDifferentTimeSteps)
 	}
 }
 
-void EventCallbackInstance1(const char* element_name, double timestamp, bool start)
+void ConditionCallbackInstance1(const char* element_name, double timestamp)
 {
-	EXPECT_STREQ(element_name, "slowdown event");
+	EXPECT_STREQ(element_name, "position trigger");
 	EXPECT_NEAR(timestamp, 3.4, 1E-4);
 	EXPECT_NEAR((float)timestamp, SE_GetSimulationTime(), 1E-4);
-	EXPECT_EQ(start, true);
 }
 
-TEST(EventCallbackTest, TestEventCallback)
+TEST(EventCallbackTest, TestConditionCallback)
 {
 	std::string scenario_file = "../../../EnvironmentSimulator/Unittest/xosc/highway_exit.xosc";
 
@@ -3309,7 +3308,7 @@ TEST(EventCallbackTest, TestEventCallback)
 	int n_Objects = SE_GetNumberOfObjects();
 	EXPECT_EQ(n_Objects, 2);
 
-	SE_RegisterEventCallback(EventCallbackInstance1);
+	SE_RegisterConditionCallback(ConditionCallbackInstance1);
 
 	// Just run until passed 3.4 seconds to cover first event triggering
 	for (int i = 0; i < 36; i++)

--- a/EnvironmentSimulator/Unittest/ScenarioEngineDll_test.cpp
+++ b/EnvironmentSimulator/Unittest/ScenarioEngineDll_test.cpp
@@ -3294,8 +3294,8 @@ TEST(ReplayTest, TestMultiReplayDifferentTimeSteps)
 
 void ConditionCallbackInstance1(const char* element_name, double timestamp)
 {
-	EXPECT_STREQ(element_name, "position trigger");
-	EXPECT_NEAR(timestamp, 3.4, 1E-4);
+	EXPECT_STREQ(element_name, "act_start");
+	EXPECT_NEAR(timestamp, 0.1, 1E-4);
 	EXPECT_NEAR((float)timestamp, SE_GetSimulationTime(), 1E-4);
 }
 
@@ -3310,8 +3310,8 @@ TEST(EventCallbackTest, TestConditionCallback)
 
 	SE_RegisterConditionCallback(ConditionCallbackInstance1);
 
-	// Just run until passed 3.4 seconds to cover first event triggering
-	for (int i = 0; i < 36; i++)
+	// Just run for two steps such that the act gets started
+	for (int i = 0; i < 2; i++)
 	{
 		SE_StepDT(0.1f);
 	}


### PR DESCRIPTION
Hi Emil, 
As discussed in #311, here is the PR to remove the old callback (SE_RegisterEventCallback).

Whilst removing the respective test I saw that there is another test for SE_RegisterStoryBoardElementStateChangeCallback, but none for SE_RegisterConditionCallback. Therefore, instead of removing it, I reused the existing test for SE_RegisterEventCallback to create one for SE_RegisterConditionCallback.

Feel free to make further adjustments or remove the test, if you do not see it as useful.

Thanks again for your great work,
Christoph