### PR TITLE
Replaced function pointer callbacks with function objects

### DIFF
--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -89,7 +89,7 @@ static void resetScenario(void)
 
 	// Reset (global) callbacks
 	OSCCondition::conditionCallback = nullptr;
-    StoryBoardElement::stateChangeCallback = nullptr;
+	StoryBoardElement::stateChangeCallback = {};
 
 	time_stamp = 0;
 }
@@ -460,6 +460,11 @@ static int InitScenario()
 	}
 
 	return 0;
+}
+
+SE_DLL_API void SE_RegisterStoryBoardElementStateChangeCallback(std::function<void(const char*, int, int)> fn)
+{
+	StoryBoardElement::stateChangeCallback = fn;
 }
 
 extern "C"

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -1437,3 +1437,8 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
+
+#ifdef __cplusplus
+#include <functional>
+SE_DLL_API void SE_RegisterStoryBoardElementStateChangeCallback(std::function<void(const char*, int, int)> fn);
+#endif

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCAction.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCAction.cpp
@@ -14,7 +14,7 @@
 
 using namespace scenarioengine;
 
-void (*StoryBoardElement::stateChangeCallback)(const char* name, int type, int state) = nullptr;
+std::function<void(const char* name, int type, int state)> StoryBoardElement::stateChangeCallback = nullptr;
 
 std::string StoryBoardElement::state2str(StoryBoardElement::State state)
 {

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCAction.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCAction.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "Entities.hpp"
+#include <functional>
 
 namespace scenarioengine
 {
@@ -20,9 +21,9 @@ namespace scenarioengine
 	class StoryBoardElement
 	{
 	public:
-        static void (*stateChangeCallback)(const char* name, int type, int state);
-
-        /**
+        static std::function<void(const char* name, int type, int state)> stateChangeCallback;
+        
+		/**
          * Take note, changing this enum will alter the public API in esminiLib.hpp
          */
 		typedef enum


### PR DESCRIPTION
Replaced c-style function pointers for StoryBoardChange in esminiLib.cpp with std::function to avoid forcing static methods on users of the API. Amended the external API with a function for accepting std::functions alongside the current function pointer signature.

If this is accepted as a good idea I aim to do the same for the other SE_RegisterXXXCallbacks.