### PR TITLE
Fixed osi library paths in cmakelists (OSI -> osi)

### DIFF
--- a/Hello-World_coding-example/tutorial.adoc
+++ b/Hello-World_coding-example/tutorial.adoc
@@ -341,9 +341,9 @@ target_link_libraries(${TARGET} esminiLib libprotobuf open_simulation_interface_
 
 Linux:
 ----
-include_directories(. ../include ../EnvironmentSimulator/Libraries/esminiLib ../externals/OSI/linux/include)
+include_directories(. ../include ../EnvironmentSimulator/Libraries/esminiLib ../externals/osi/linux/include)
 
-link_directories(. ../bin ../externals/OSI/linux/lib)
+link_directories(. ../bin ../externals/osi/linux/lib)
 
 target_link_libraries(${TARGET} esminiLib protobuf open_simulation_interface_pic)
 ----

--- a/Hello-World_coding-example/tutorial.adoc
+++ b/Hello-World_coding-example/tutorial.adoc
@@ -332,9 +332,9 @@ To access OSI data we first need to complement the build script (CMakeLists.txt)
 
 Windows:
 ----
-include_directories(. ../include ../EnvironmentSimulator/Libraries/esminiLib ../externals/OSI/v10/include)
+include_directories(. ../include ../EnvironmentSimulator/Libraries/esminiLib ../externals/osi/v10/include)
 
-link_directories(. ../bin ../externals/OSI/v10/lib)
+link_directories(. ../bin ../externals/osi/v10/lib)
 
 target_link_libraries(${TARGET} esminiLib libprotobuf open_simulation_interface_pic)
 ----


### PR DESCRIPTION
This PR fixes a bug in the coding example regarding OSI GroundTruth. There is a mistake in the paths of the OSI include and lib directory. It has to be `osi` and not `OSI`.