### PR TITLE
Added OpenMSL to Related Work

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ see [User Guide Hello-World tutorial](https://esmini.github.io/#_python_binding)
 ### Carla Simulator
 [Carla](http://carla.org/) is an [Unreal](https://www.unrealengine.com/) based open source simulator worth to check out.
 
+### OpenMSL
+[Open Source Model & Simulation Library](https://github.com/openmsl) is a central hub for simulation entities for virtual ADAS testing. It runs a co-simulation with esmini in a GitHub action for sensor model testing and therefore demonstrates its application with other simulation models.
+
 ## Data formats
 
 [OpenDRIVE](https://www.asam.net/standards/detail/opendrive/)


### PR DESCRIPTION
I added OpenMSL to the Related Work section in the Readme. I think this will benefit the users as they can see, how esmini is used in a co-simulation with other FMUs directly in a GitHub action to test sensor models.

Further applications e.g. für OpenDrive and OpenScenario files will follow in OpenMSL.

I also linked esmini in the [Related Work in OpenMSL](https://github.com/openMSL/.github/blob/main/doc/related_work.md).