### PR TITLE
Added SE_AddObjectWithBoundingBox()

### DIFF
--- a/EnvironmentSimulator/Libraries/esminiLib/ESMiniWrapper.cs
+++ b/EnvironmentSimulator/Libraries/esminiLib/ESMiniWrapper.cs
@@ -111,6 +111,29 @@ namespace ESMini
         public bool opposite_lanes; // true if the two position objects are in opposite sides of reference lane
     };
 
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Center
+    {
+        public float x_;            // Center offset in x direction.
+        public float y_;            // Center offset in y direction.
+        public float z_;            // Center offset in z direction.
+    };
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Dimensions
+    {
+        public float width_;            // Width of the entity's bounding box. Unit: m; Range: [0..inf[.
+        public float length_;           // Length of the entity's bounding box. Unit: m; Range: [0..inf[.
+        public float height_;           // Height of the entity's bounding box. Unit: m; Range: [0..inf[.
+    };
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct OSCBoundingBox
+    {
+        public Center center_;           // Represents the geometrical center of the bounding box
+        public Dimensions dimensions_;   // Width, length and height of the bounding box.
+    };
+
 
 public static class ESMiniLib
     {
@@ -235,6 +258,17 @@ public static class ESMiniLib
         /// <param name="model_id">Id of the 3D model to represent the object. See resources/model_ids.txt.</param>
         /// <returns> @return Id [0..inf] of the added object successful, -1 on failure</returns>
         public static extern int SE_AddObject(string object_name, int object_type, int object_category, int object_role, int model_id);
+
+        [DllImport(LIB_NAME, EntryPoint = "SE_AddObjectWithBoundingBox")]
+        /// <summary>Add object with bounding box. Sets scale mode to MODEL_TO_BB. Should be followed by one of the SE_Report functions to establish initial state.</summary>
+        /// <param name="object_name">Name of the object, preferably be unique</param>
+        /// <param name="object_type">Type of the object. See Entities.hpp::Object::Type. Default=1 (VEHICLE).</param>
+        /// <param name="object_category">Category of the object. Depends on type, see descendants of Entities.hpp::Object. Set to 0 if not known.</param>
+        /// <param name="object_role"> role of the object. Depends on type, See Entities.hpp::Object::Role. Set to 0 if not known.</param>
+        /// <param name="model_id">Id of the 3D model to represent the object. See resources/model_ids.txt.</param>
+        /// <param name="bounding_box">sets the internal bounding box of the model and will also be used to scale 3D model accordingly.</param>
+        /// <returns> @return Id [0..inf] of the added object successful, -1 on failure</returns>
+        public static extern int SE_AddObjectWithBoundingBox(string object_name, int object_type, int object_category, int object_role, int model_id, ref OSCBoundingBox bounding_box);
 
         [DllImport(LIB_NAME, EntryPoint = "SE_DeleteObject")]
         /// <summary>Delete object</summary>

--- a/EnvironmentSimulator/Libraries/esminiLib/ESMiniWrapper.cs
+++ b/EnvironmentSimulator/Libraries/esminiLib/ESMiniWrapper.cs
@@ -48,8 +48,8 @@ namespace ESMini
         public float width;
         public float length;
         public float height;
-        public int   objectType;     // Main type according to entities.hpp / Object / Type (NONE=0, VEHICLE=1, PEDESTRIAN=2, MISC_OBJECT=3)
-        public int   objectCategory; // Sub category within type, according to entities.hpp / Vehicle, Pedestrian, MiscObject / Category
+        public int objectType;     // Main type according to entities.hpp / Object / Type (NONE=0, VEHICLE=1, PEDESTRIAN=2, MISC_OBJECT=3)
+        public int objectCategory; // Sub category within type, according to entities.hpp / Vehicle, Pedestrian, MiscObject / Category
         public float wheel_angle;
         public float wheel_rotation;
     };
@@ -135,7 +135,7 @@ namespace ESMini
     };
 
 
-public static class ESMiniLib
+    public static class ESMiniLib
     {
         private const string LIB_NAME = "esminiLib";
 
@@ -267,8 +267,9 @@ public static class ESMiniLib
         /// <param name="object_role"> role of the object. Depends on type, See Entities.hpp::Object::Role. Set to 0 if not known.</param>
         /// <param name="model_id">Id of the 3D model to represent the object. See resources/model_ids.txt.</param>
         /// <param name="bounding_box">sets the internal bounding box of the model and will also be used to scale 3D model accordingly.</param>
+        /// <param name="scale_mode">0=NONE, 1=BB_TO_MODEL, 2=MODEL_TO_BB (see CommonMini::EntityScaleMode enum)</param>
         /// <returns> @return Id [0..inf] of the added object successful, -1 on failure</returns>
-        public static extern int SE_AddObjectWithBoundingBox(string object_name, int object_type, int object_category, int object_role, int model_id, ref OSCBoundingBox bounding_box);
+        public static extern int SE_AddObjectWithBoundingBox(string object_name, int object_type, int object_category, int object_role, int model_id, ref OSCBoundingBox bounding_box, int scale_mode);
 
         [DllImport(LIB_NAME, EntryPoint = "SE_DeleteObject")]
         /// <summary>Delete object</summary>
@@ -380,7 +381,7 @@ public static class ESMiniLib
         /// <returns> Number of identified objects, i.e.length of list. -1 on failure</returns>
         public static extern int SE_FetchSensorObjectList(int object_id, int[] list);
 
-		[DllImport(LIB_NAME, EntryPoint = "SE_GetRoadInfoAtDistance")]
+        [DllImport(LIB_NAME, EntryPoint = "SE_GetRoadInfoAtDistance")]
         /// <summary>Get information suitable for driver modeling of a point at a specified distance from object along the road ahead</summary>
         /// <param name="object_id">Handle to the position object from which to measure</param>
         /// <param name="lookahead_distance">The distance, along the road, to the point</param>

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -1039,77 +1039,8 @@ extern "C"
 
     SE_DLL_API int SE_AddObject(const char *object_name, int object_type, int object_category, int object_role, int model_id)
     {
-        int object_id = -1;
-
-        // Add missing object
-        if (player != nullptr)
-        {
-            std::string name;
-            if (object_name == nullptr)
-            {
-                name = "obj_" + std::to_string(object_id);
-            }
-            else
-            {
-                name = object_name;
-            }
-
-            if (object_type < 1 || object_type >= scenarioengine::Object::Type::N_OBJECT_TYPES)
-            {
-                object_type = scenarioengine::Object::Type::VEHICLE;
-            }
-
-            Vehicle *vehicle = nullptr;
-            if (object_type == scenarioengine::Object::Type::VEHICLE)
-            {
-                vehicle             = new Vehicle();
-                object_id           = player->scenarioEngine->entities_.addObject(vehicle, true);
-                vehicle->name_      = name;
-                vehicle->scaleMode_ = EntityScaleMode::BB_TO_MODEL;
-                vehicle->model_id_  = model_id;
-                vehicle->model3d_   = SE_Env::Inst().GetModelFilenameById(model_id);
-                vehicle->category_  = object_category;
-                vehicle->role_      = object_role;
-
-                Controller::InitArgs args = {"", "", 0, 0, 0, 0};
-                args.type                 = ControllerExternal::GetTypeNameStatic();
-                vehicle->controller_      = InstantiateControllerExternal(&args);
-                vehicle->controller_->Activate(ControlDomains::DOMAIN_BOTH);
-            }
-            else
-            {
-                LOG("SE_AddObject: Object type %d not supported yet", object_type);
-                return -1;
-            }
-
-            scenarioengine::OSCBoundingBox bb = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
-            if (player->scenarioGateway->reportObject(object_id,
-                                                      name,
-                                                      object_type,
-                                                      object_category,
-                                                      object_role,
-                                                      model_id,
-                                                      vehicle->GetActivatedControllerType(),
-                                                      bb,
-                                                      static_cast<int>(EntityScaleMode::BB_TO_MODEL),
-                                                      0xff,
-                                                      0.0,
-                                                      0.0,
-                                                      0.0,
-                                                      0.0,
-                                                      0.0,
-                                                      0.0,
-                                                      0.0,
-                                                      0.0,
-                                                      0.0,
-                                                      0.0,
-                                                      0.0) == 0)
-            {
-                return object_id;
-            }
-        }
-
-        return -1;
+        SE_OSCBoundingBox bb = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
+        return SE_AddObjectWithBoundingBox(object_name, object_type, object_category, object_role, model_id, bb, 1);
     }
 
     SE_DLL_API int SE_AddObjectWithBoundingBox(const char       *object_name,
@@ -1117,7 +1048,8 @@ extern "C"
                                                int               object_category,
                                                int               object_role,
                                                int               model_id,
-                                               SE_OSCBoundingBox bounding_box)
+                                               SE_OSCBoundingBox bounding_box,
+                                               int               scale_mode)
     {
         int object_id = -1;
 
@@ -1139,25 +1071,25 @@ extern "C"
                 object_type = scenarioengine::Object::Type::VEHICLE;
             }
 
-            Vehicle *vehicle = nullptr;
+            Vehicle                       *vehicle = nullptr;
             scenarioengine::OSCBoundingBox bb;
-            bb.center_.x_ = bounding_box.center_.x_;
-            bb.center_.y_ = bounding_box.center_.y_;
-            bb.center_.z_ = bounding_box.center_.z_;
+            bb.center_.x_          = bounding_box.center_.x_;
+            bb.center_.y_          = bounding_box.center_.y_;
+            bb.center_.z_          = bounding_box.center_.z_;
             bb.dimensions_.height_ = bounding_box.dimensions_.height_;
             bb.dimensions_.length_ = bounding_box.dimensions_.length_;
             bb.dimensions_.width_  = bounding_box.dimensions_.width_;
 
             if (object_type == scenarioengine::Object::Type::VEHICLE)
             {
-                vehicle             = new Vehicle();
-                object_id           = player->scenarioEngine->entities_.addObject(vehicle, true);
-                vehicle->name_      = name;
-                vehicle->scaleMode_ = EntityScaleMode::MODEL_TO_BB;
-                vehicle->model_id_  = model_id;
-                vehicle->model3d_   = SE_Env::Inst().GetModelFilenameById(model_id);
-                vehicle->category_  = object_category;
-                vehicle->role_      = object_role;
+                vehicle               = new Vehicle();
+                object_id             = player->scenarioEngine->entities_.addObject(vehicle, true);
+                vehicle->name_        = name;
+                vehicle->scaleMode_   = static_cast<EntityScaleMode>(scale_mode);
+                vehicle->model_id_    = model_id;
+                vehicle->model3d_     = SE_Env::Inst().GetModelFilenameById(model_id);
+                vehicle->category_    = object_category;
+                vehicle->role_        = object_role;
                 vehicle->boundingbox_ = bb;
 
                 Controller::InitArgs args = {"", "", 0, 0, 0, 0};
@@ -1199,7 +1131,7 @@ extern "C"
 
         return -1;
     }
-    
+
     SE_DLL_API int SE_DeleteObject(int object_id)
     {
         Object *obj = nullptr;

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -209,6 +209,27 @@ typedef struct
     unsigned char *data;
 } SE_Image;  // Should be synked with CommonMini/OffScreenImage
 
+
+typedef struct
+{
+    float x_;  // Center offset in x direction.
+    float y_;  // Center offset in y direction.
+    float z_;  // Center offset in z direction.
+} SE_Center;
+
+typedef struct
+{
+    float width_;  // Width of the entity's bounding box. Unit: m; Range: [0..inf[.
+    float length_;  // Length of the entity's bounding box. Unit: m; Range: [0..inf[.
+    float height_;  // Height of the entity's bounding box. Unit: m; Range: [0..inf[.
+} SE_Dimensions;
+
+typedef struct
+{
+    SE_Center  center_;      // Represents the geometrical center of the bounding box
+    SE_Dimensions dimensions_;  // Width, length and height of the bounding box.
+} SE_OSCBoundingBox;
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -706,6 +727,23 @@ extern "C"
             @return Id [0..inf] of the added object successful, -1 on failure
     */
     SE_DLL_API int SE_AddObject(const char *object_name, int object_type, int object_category, int object_role, int model_id);
+    /**
+            Add object with bounding box. Sets scale mode to MODEL_TO_BB.
+            Should be followed by one of the SE_Report functions to establish initial state.
+            @param object_name Name of the object, preferably be unique
+            @param object_type Type of the object. See Entities.hpp::Object::Type. Default=1 (VEHICLE).
+            @param object_category Category of the object. Depends on type, see descendants of Entities.hpp::Object. Set to 0 if not known.
+            @param object_role role of the object. Depends on type, See Entities.hpp::Object::Role. Set to 0 if not known.
+            @param model_id Id of the 3D model to represent the object. See resources/model_ids.txt.
+            @param bounding_box sets the internal bounding box of the model and will also be used to scale 3D model accordingly.
+            @return Id [0..inf] of the added object successful, -1 on failure
+    */
+    SE_DLL_API int SE_AddObjectWithBoundingBox(const char       *object_name,
+                                               int               object_type,
+                                               int               object_category,
+                                               int               object_role,
+                                               int               model_id,
+                                               SE_OSCBoundingBox bounding_box);
 
     /**
             Delete object

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -209,7 +209,6 @@ typedef struct
     unsigned char *data;
 } SE_Image;  // Should be synked with CommonMini/OffScreenImage
 
-
 typedef struct
 {
     float x_;  // Center offset in x direction.
@@ -219,14 +218,14 @@ typedef struct
 
 typedef struct
 {
-    float width_;  // Width of the entity's bounding box. Unit: m; Range: [0..inf[.
+    float width_;   // Width of the entity's bounding box. Unit: m; Range: [0..inf[.
     float length_;  // Length of the entity's bounding box. Unit: m; Range: [0..inf[.
     float height_;  // Height of the entity's bounding box. Unit: m; Range: [0..inf[.
 } SE_Dimensions;
 
 typedef struct
 {
-    SE_Center  center_;      // Represents the geometrical center of the bounding box
+    SE_Center     center_;      // Represents the geometrical center of the bounding box
     SE_Dimensions dimensions_;  // Width, length and height of the bounding box.
 } SE_OSCBoundingBox;
 
@@ -736,6 +735,7 @@ extern "C"
             @param object_role role of the object. Depends on type, See Entities.hpp::Object::Role. Set to 0 if not known.
             @param model_id Id of the 3D model to represent the object. See resources/model_ids.txt.
             @param bounding_box sets the internal bounding box of the model and will also be used to scale 3D model accordingly.
+            @param scale_mode 0=NONE, 1=BB_TO_MODEL, 2=MODEL_TO_BB (see CommonMini::EntityScaleMode enum)
             @return Id [0..inf] of the added object successful, -1 on failure
     */
     SE_DLL_API int SE_AddObjectWithBoundingBox(const char       *object_name,
@@ -743,7 +743,8 @@ extern "C"
                                                int               object_category,
                                                int               object_role,
                                                int               model_id,
-                                               SE_OSCBoundingBox bounding_box);
+                                               SE_OSCBoundingBox bounding_box,
+                                               int               scale_mode);
 
     /**
             Delete object


### PR DESCRIPTION
Hello!

For my use case, I need to be able to manually define the boundary box of a vehicle when adding it using SE_AddObject().
I thus have added the function SE_AddObjectWithBoundingBox() which has the additional parameter SE_OSCBoundingBox bounding_box. I was not sure, if it would make sense to overwrite SE_AddObject() instead of adding a new function.
Also the scaleMode has been changed to MODEL_TO_BB.
Do you guys think that these changes make sense to integrate into esmini?