### PR TITLE
Add TrafficUpdate Input to OSMP FMU

### DIFF
--- a/OSMP_FMU/EsminiOsiSource.h
+++ b/OSMP_FMU/EsminiOsiSource.h
@@ -49,11 +49,13 @@ using namespace std;
 
 
 /* Integer Variables */
-#define FMI_INTEGER_SENSORVIEW_OUT_BASELO_IDX 0
-#define FMI_INTEGER_SENSORVIEW_OUT_BASEHI_IDX 1
-#define FMI_INTEGER_SENSORVIEW_OUT_SIZE_IDX 2
-#define FMI_INTEGER_COUNT_IDX 3
-#define FMI_INTEGER_LAST_IDX FMI_INTEGER_COUNT_IDX
+#define FMI_INTEGER_TRAFFICUPDATE_IN_BASELO_IDX 0
+#define FMI_INTEGER_TRAFFICUPDATE_IN_BASEHI_IDX 1
+#define FMI_INTEGER_TRAFFICUPDATE_IN_SIZE_IDX 2
+#define FMI_INTEGER_SENSORVIEW_OUT_BASELO_IDX 3
+#define FMI_INTEGER_SENSORVIEW_OUT_BASEHI_IDX 4
+#define FMI_INTEGER_SENSORVIEW_OUT_SIZE_IDX 5
+#define FMI_INTEGER_LAST_IDX FMI_INTEGER_SENSORVIEW_OUT_SIZE_IDX
 #define FMI_INTEGER_VARS (FMI_INTEGER_LAST_IDX+1)
 
 /* Real Variables */
@@ -201,12 +203,11 @@ protected:
     void set_fmi_valid(fmi2Boolean value) { boolean_vars[FMI_BOOLEAN_VALID_IDX]=value; }
     fmi2Boolean fmi_use_viewer() { return boolean_vars[FMI_BOOLEAN_USE_VIEWER_IDX]; }
     void set_fmi_use_viewer(fmi2Boolean value) { boolean_vars[FMI_BOOLEAN_USE_VIEWER_IDX]=value; }
-    fmi2Integer fmi_count() { return integer_vars[FMI_INTEGER_COUNT_IDX]; }
-    void set_fmi_count(fmi2Integer value) { integer_vars[FMI_INTEGER_COUNT_IDX]=value; }
     string fmi_xosc_path() { return string_vars[FMI_STRING_XOSC_PATH_IDX]; }
     void set_fmi_xosc_path(string value) { string_vars[FMI_STRING_XOSC_PATH_IDX]=value; }
 
     /* Protocol Buffer Accessors */
+    bool get_fmi_traffic_update_in(osi3::TrafficUpdate& data);
     void set_fmi_sensor_view_out(const osi3::SensorView& data);
     void reset_fmi_sensor_view_out();
 };

--- a/OSMP_FMU/README.md
+++ b/OSMP_FMU/README.md
@@ -3,8 +3,8 @@
 This example compiles an [OSMP FMU](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging) with which esmini can be used in an FMU-based co-simulation. <br>
 Esmini is initialized via the API in the *doInit* function of the FMU.
 The path to the xosc file has to be set with the FMI parameter *xosc_path*. <br>
-In the *doCalc* function (a subsequent function of *doStep*), the OSI ground truth data is fetched via the API and copied to an OSI SensorView message.
-The SensorView is the output of the FMU.
+In the *doCalc* function (a subsequent function of *doStep*), first an optional osi3::TrafficUpdate input is processed, then the OSI ground truth data is fetched via the API and copied to an OSI SensorView message.
+The SensorView is the output of the FMU. The FMU can be used in either open-loop or closed-loop simulation.
 
 ### Usage
 - First build esmini according to the [build instructions](https://esmini.github.io/#_build_esmini_quick_guide).
@@ -19,9 +19,14 @@ The SensorView is the output of the FMU.
 - Run the FMU in a co-simulation, e.g. by using the open source framework [OpenMCx](https://github.com/eclipse/openmcx).
 Be sure to set the OpenScenario file as FMI parameter *xosc_path*.
 Furthermore, you can set, if the scenario viewer is displayed with the boolean FMI parameter *use_viewer*.
+The esmini OSMP FMU can be used in either open-loop or closed-loop configuration.
+  - Open-loop: Leave the osi3::TrafficUpdate input empty.
+  Then the scenario is played step-by-step as defined in the OpenScenario file.
+  - Closed-loop: Connect a traffic participant model via the TrafficUpdate interface to the input of the esmini OSMP FMU.
+  Currently, updates on x- and y-position, heading (yaw angle) and velocity are supported.
 
 ### Static or Dynamic linking of esmini
-By default esmini will be linked statically for better portability of the FMU. To link dynamically instead, modify STATIC_LINKING variable in CMakeLists.txt as:
+By default, esmini will be linked statically for better portability of the FMU. To link dynamically instead, modify STATIC_LINKING variable in CMakeLists.txt as:
 
 `set(STATIC_LINKING FALSE)`
 

--- a/OSMP_FMU/modelDescription.in.xml
+++ b/OSMP_FMU/modelDescription.in.xml
@@ -22,24 +22,42 @@
     <Category name="OSMP" description="Enable OSMP-related logging"/>
     <Category name="OSI" description="Enable OSI-related logging"/>
   </LogCategories>
-  <DefaultExperiment startTime="0.0" stepSize="0.020"/>
+  <DefaultExperiment startTime="0.0" stepSize="0.10"/>
   <VendorAnnotations>
     <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp version="@OSMPVERSION@" osi-version="@OSIVERSION@"/></Tool>
   </VendorAnnotations>
   <ModelVariables>
-    <ScalarVariable name="OSMPSensorViewOut.base.lo" valueReference="0" causality="output" variability="discrete" initial="exact">
+    <ScalarVariable name="OSMPTrafficUpdateIn.base.lo" valueReference="0" causality="input" variability="discrete">
+      <Integer start="0"/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPTrafficUpdateIn" role="base.lo" mime-type="application/x-open-simulation-interface; type=TrafficUpdate; version=@OSIVERSION@"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPTrafficUpdateIn.base.hi" valueReference="1" causality="input" variability="discrete">
+      <Integer start="0"/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPTrafficUpdateIn" role="base.hi" mime-type="application/x-open-simulation-interface; type=TrafficUpdate; version=@OSIVERSION@"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPTrafficUpdateIn.size" valueReference="2" causality="input" variability="discrete">
+      <Integer start="0"/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPTrafficUpdateIn" role="size" mime-type="application/x-open-simulation-interface; type=TrafficUpdate; version=@OSIVERSION@"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPSensorViewOut.base.lo" valueReference="3" causality="output" variability="discrete" initial="exact">
       <Integer start="0"/>
       <Annotations>
         <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewOut" role="base.lo" mime-type="application/x-open-simulation-interface; type=SensorView; version=@OSIVERSION@"/></Tool>
       </Annotations>
     </ScalarVariable>
-    <ScalarVariable name="OSMPSensorViewOut.base.hi" valueReference="1" causality="output" variability="discrete" initial="exact">
+    <ScalarVariable name="OSMPSensorViewOut.base.hi" valueReference="4" causality="output" variability="discrete" initial="exact">
       <Integer start="0"/>
       <Annotations>
         <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewOut" role="base.hi" mime-type="application/x-open-simulation-interface; type=SensorView; version=@OSIVERSION@"/></Tool>
       </Annotations>
     </ScalarVariable>
-    <ScalarVariable name="OSMPSensorViewOut.size" valueReference="2" causality="output" variability="discrete" initial="exact">
+    <ScalarVariable name="OSMPSensorViewOut.size" valueReference="5" causality="output" variability="discrete" initial="exact">
       <Integer start="0"/>
       <Annotations>
         <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewOut" role="size" mime-type="application/x-open-simulation-interface; type=SensorView; version=@OSIVERSION@"/></Tool>
@@ -51,20 +69,16 @@
     <ScalarVariable name="use_viewer" valueReference="1" causality="parameter" variability="discrete" initial="exact">
       <Boolean start="false"/>
     </ScalarVariable>
-    <ScalarVariable name="count" valueReference="3" causality="output" variability="discrete" initial="exact">
-      <Integer start="0"/>
-    </ScalarVariable>
     <ScalarVariable name="xosc_path" valueReference="0" causality="parameter" variability="fixed">
       <String start=""/>
     </ScalarVariable>
   </ModelVariables>
   <ModelStructure>
     <Outputs>
-      <Unknown index="1"/>
-      <Unknown index="2"/>
-      <Unknown index="3"/>
       <Unknown index="4"/>
       <Unknown index="5"/>
+      <Unknown index="6"/>
+      <Unknown index="7"/>
     </Outputs>
   </ModelStructure>
 </fmiModelDescription>


### PR DESCRIPTION
Fixes #462 

Added an osi3::TrafficUpdate input to the esmini OSMP FMU. This way esmini can be used in a closed-loop co-simulation with a traffic participant model.

In this version, the FMU can handle updates on x- and y-position, heading (yaw angle) and velocity. More update parameters can be added in the future.

An example usage in a co-simulation with a simple traffic participant model can be found in [OpenMSL](https://github.com/openMSL/sl-2-0-traffic-participant-model-repository-template/tree/inital-template/test/integration/002_smoke_test_scenario).