### PR TITLE
[roadmngr] const correctness on class methods

### DIFF
--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -5078,7 +5078,8 @@ int OpenDrive::GetTrackIdByIdx(int idx) const
     return 0;
 }
 
-bool OpenDrive::IsIndirectlyConnected(int road1_id, int road2_id, int*& connecting_road_id, int*& connecting_lane_id, int lane1_id, int lane2_id) const
+bool OpenDrive::IsIndirectlyConnected(int road1_id, int road2_id, int*& connecting_road_id, int*& connecting_lane_id, int lane1_id, int lane2_id)
+    const
 {
     Road*     road1 = GetRoadById(road1_id);
     Road*     road2 = GetRoadById(road2_id);

--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -449,21 +449,21 @@ int roadmanager::CheckOverlapingOSIPoints(OSIPoints* first_set, OSIPoints* secon
     return retvalue;
 }
 
-double Polynomial::Evaluate(double p)
+double Polynomial::Evaluate(double p) const
 {
     p *= p_scale_;
 
     return (a_ + p * b_ + p * p * c_ + p * p * p * d_);
 }
 
-double Polynomial::EvaluatePrim(double p)
+double Polynomial::EvaluatePrim(double p) const
 {
     p *= p_scale_;
 
     return (b_ + 2 * p * c_ + 3 * p * p * d_);
 }
 
-double Polynomial::EvaluatePrimPrim(double p)
+double Polynomial::EvaluatePrimPrim(double p) const
 {
     p *= p_scale_;
 
@@ -495,7 +495,7 @@ PointStruct& OSIPoints::GetPoint(int i)
     }
 }
 
-double OSIPoints::GetXfromIdx(int i)
+double OSIPoints::GetXfromIdx(int i) const
 {
     if (point_.size() <= i || point_.size() == 0)
     {
@@ -511,7 +511,7 @@ double OSIPoints::GetXfromIdx(int i)
     }
 }
 
-double OSIPoints::GetYfromIdx(int i)
+double OSIPoints::GetYfromIdx(int i) const
 {
     if (point_.size() <= i || point_.size() == 0)
     {
@@ -527,7 +527,7 @@ double OSIPoints::GetYfromIdx(int i)
     }
 }
 
-double OSIPoints::GetZfromIdx(int i)
+double OSIPoints::GetZfromIdx(int i) const
 {
     if (point_.size() <= i || point_.size() == 0)
     {
@@ -543,12 +543,12 @@ double OSIPoints::GetZfromIdx(int i)
     }
 }
 
-int OSIPoints::GetNumOfOSIPoints()
+int OSIPoints::GetNumOfOSIPoints() const
 {
     return (int)point_.size();
 }
 
-double OSIPoints::GetLength()
+double OSIPoints::GetLength() const
 {
     double length = 0;
     for (int i = 0; i < point_.size() - 1; i++)
@@ -558,12 +558,12 @@ double OSIPoints::GetLength()
     return length;
 }
 
-void Geometry::Print()
+void Geometry::Print() const
 {
     LOG("Geometry virtual Print");
 }
 
-void Geometry::EvaluateDS(double ds, double* x, double* y, double* h)
+void Geometry::EvaluateDS(double ds, double* x, double* y, double* h) const
 {
     (void)ds;
     (void)x;
@@ -572,19 +572,19 @@ void Geometry::EvaluateDS(double ds, double* x, double* y, double* h)
     LOG("Geometry virtual Evaluate");
 }
 
-void Line::Print()
+void Line::Print() const
 {
     LOG("Line x: %.2f, y: %.2f, h: %.2f length: %.2f", GetX(), GetY(), GetHdg(), GetLength());
 }
 
-void Line::EvaluateDS(double ds, double* x, double* y, double* h)
+void Line::EvaluateDS(double ds, double* x, double* y, double* h) const
 {
     *h = GetHdg();
     *x = GetX() + ds * cos(*h);
     *y = GetY() + ds * sin(*h);
 }
 
-double Arc::GetRadius()
+double Arc::GetRadius() const
 {
     if (abs(curvature_) < SMALL_NUMBER)
     {
@@ -596,12 +596,12 @@ double Arc::GetRadius()
     }
 }
 
-void Arc::Print()
+void Arc::Print() const
 {
     LOG("Arc x: %.2f, y: %.2f, h: %.2f curvature: %.2f length: %.2f", GetX(), GetY(), GetHdg(), curvature_, GetLength());
 }
 
-void Arc::EvaluateDS(double ds, double* x, double* y, double* h)
+void Arc::EvaluateDS(double ds, double* x, double* y, double* h) const
 {
     double x_local = 0.0;
     double y_local = 0.0;
@@ -683,7 +683,7 @@ Spiral::Spiral(double s, double x, double y, double hdg, double length, double c
     }
 }
 
-void Spiral::Print()
+void Spiral::Print() const
 {
     LOG("Spiral x: %.2f, y: %.2f, h: %.2f start curvature: %.4f end curvature: %.4f length: %.2f %s",
         GetX(),
@@ -697,7 +697,7 @@ void Spiral::Print()
                      : "");
 }
 
-void Spiral::EvaluateDS(double ds, double* x, double* y, double* h)
+void Spiral::EvaluateDS(double ds, double* x, double* y, double* h) const
 {
     double xTmp, yTmp, t;
 
@@ -729,7 +729,7 @@ void Spiral::EvaluateDS(double ds, double* x, double* y, double* h)
     }
 }
 
-double Spiral::EvaluateCurvatureDS(double ds)
+double Spiral::EvaluateCurvatureDS(double ds) const
 {
     if (line_ != 0)
     {
@@ -806,7 +806,7 @@ Poly3::Poly3(double s, double x, double y, double hdg, double length, double a, 
     SetUMax(xTmp);
 }
 
-void Poly3::Print()
+void Poly3::Print() const
 {
     LOG("Poly3 x: %.2f, y: %.2f, h: %.2f length: %.2f a: %.2f b: %.2f c: %.2f d: %.2f",
         GetX(),
@@ -819,7 +819,7 @@ void Poly3::Print()
         poly3_.GetD());
 }
 
-void Poly3::EvaluateDSLocal(double ds, double& u, double& v)
+void Poly3::EvaluateDSLocal(double ds, double& u, double& v) const
 {
     double distTmp = 0;
     double steplen = MIN(10, ds);  // along u axis - to be tuned
@@ -853,7 +853,7 @@ void Poly3::EvaluateDSLocal(double ds, double& u, double& v)
     }
 }
 
-void Poly3::EvaluateDS(double ds, double* x, double* y, double* h)
+void Poly3::EvaluateDS(double ds, double* x, double* y, double* h) const
 {
     double u_local = 0;
     double v_local = 0;
@@ -865,12 +865,12 @@ void Poly3::EvaluateDS(double ds, double* x, double* y, double* h)
     *h = GetHdg() + atan(poly3_.EvaluatePrim(u_local));
 }
 
-double Poly3::EvaluateCurvatureDS(double ds)
+double Poly3::EvaluateCurvatureDS(double ds) const
 {
     return poly3_.EvaluatePrimPrim(ds);
 }
 
-void ParamPoly3::Print()
+void ParamPoly3::Print() const
 {
     LOG("ParamPoly3 x: %.2f, y: %.2f, h: %.2f length: %.2f U: %.8f, %.8f, %.8f, %.8f V: %.8f, %.8f, %.8f, %.8f",
         GetX(),
@@ -887,7 +887,7 @@ void ParamPoly3::Print()
         poly3V_.GetD());
 }
 
-void ParamPoly3::EvaluateDS(double ds, double* x, double* y, double* h)
+void ParamPoly3::EvaluateDS(double ds, double* x, double* y, double* h) const
 {
     double p   = S2P(ds);
     double hdg = GetHdg();
@@ -900,7 +900,7 @@ void ParamPoly3::EvaluateDS(double ds, double* x, double* y, double* h)
     *h = hdg + atan2(poly3V_.EvaluatePrim(p), poly3U_.EvaluatePrim(p));
 }
 
-double ParamPoly3::EvaluateCurvatureDS(double ds)
+double ParamPoly3::EvaluateCurvatureDS(double ds) const
 {
     double up          = poly3U_.EvaluatePrim(ds);
     double upp         = poly3U_.EvaluatePrimPrim(ds);
@@ -955,7 +955,7 @@ void ParamPoly3::calcS2PMap(PRangeType p_range)
     }
 }
 
-double ParamPoly3::S2P(double s)
+double ParamPoly3::S2P(double s) const
 {
     for (size_t i = 0; i < PARAMPOLY3_STEPS; i++)
     {
@@ -968,12 +968,12 @@ double ParamPoly3::S2P(double s)
     return s2p_map_[PARAMPOLY3_STEPS][1];
 }
 
-void Elevation::Print()
+void Elevation::Print() const
 {
     LOG("Elevation: s: %.2f A: %.4f B: %.4f C: %.4f D: %.4f", GetS(), poly3_.GetA(), poly3_.GetB(), poly3_.GetC(), poly3_.GetD());
 }
 
-void LaneLink::Print()
+void LaneLink::Print() const
 {
     LOG("LaneLink type: %d id: %d", type_, id_);
 }
@@ -993,7 +993,7 @@ void LaneRoadMarkTypeLine::SetGlobalId()
     global_id_ = GetNewGlobalLaneBoundaryId();
 }
 
-LaneWidth* Lane::GetWidthByIndex(int index)
+LaneWidth* Lane::GetWidthByIndex(int index) const
 {
     if (lane_width_.size() <= index || lane_width_.size() == 0)
     {
@@ -1009,7 +1009,7 @@ LaneWidth* Lane::GetWidthByIndex(int index)
     }
 }
 
-LaneWidth* Lane::GetWidthByS(double s)
+LaneWidth* Lane::GetWidthByS(double s) const
 {
     if (lane_width_.size() == 0)
     {
@@ -1059,7 +1059,7 @@ void Lane::AddLaneRoadMark(LaneRoadMark* lane_roadMark)
     lane_roadMark_.push_back(lane_roadMark);
 }
 
-LaneLink* Lane::GetLink(LinkType type)
+LaneLink* Lane::GetLink(LinkType type) const
 {
     for (int i = 0; i < (int)link_.size(); i++)
     {
@@ -1072,12 +1072,12 @@ LaneLink* Lane::GetLink(LinkType type)
     return 0;  // No link of requested type exists
 }
 
-void LaneWidth::Print()
+void LaneWidth::Print() const
 {
     LOG("LaneWidth: sOffset: %.2f, a: %.2f, b: %.2f, c: %.2f, d: %.2f", s_offset_, poly3_.GetA(), poly3_.GetB(), poly3_.GetC(), poly3_.GetD());
 }
 
-LaneRoadMark* Lane::GetLaneRoadMarkByIdx(int idx)
+LaneRoadMark* Lane::GetLaneRoadMarkByIdx(int idx) const
 {
     if (lane_roadMark_.size() <= idx || lane_roadMark_.size() == 0)
     {
@@ -1093,7 +1093,7 @@ LaneRoadMark* Lane::GetLaneRoadMarkByIdx(int idx)
     }
 }
 
-std::vector<int> Lane::GetLineGlobalIds()
+std::vector<int> Lane::GetLineGlobalIds() const
 {
     std::vector<int> line_ids;
     for (int i = 0; i < GetNumberOfRoadMarks(); i++)
@@ -1114,7 +1114,7 @@ std::vector<int> Lane::GetLineGlobalIds()
     return line_ids;
 }
 
-int Lane::GetLaneBoundaryGlobalId()
+int Lane::GetLaneBoundaryGlobalId() const
 {
     if (lane_boundary_)
     {
@@ -1200,7 +1200,7 @@ std::string LaneRoadMark::RoadMarkColor2Str(RoadMarkColor color)
     return "Unrecognized color id: " + std::to_string(static_cast<int>(color));
 }
 
-LaneRoadMarkType* LaneRoadMark::GetLaneRoadMarkTypeByIdx(int idx)
+LaneRoadMarkType* LaneRoadMark::GetLaneRoadMarkTypeByIdx(int idx) const
 {
     if (idx < (int)lane_roadMarkType_.size())
     {
@@ -1215,7 +1215,7 @@ void LaneRoadMark::AddType(std::shared_ptr<LaneRoadMarkType> lane_roadMarkType)
     lane_roadMarkType_.push_back(lane_roadMarkType);
 }
 
-LaneRoadMarkTypeLine* LaneRoadMarkType::GetLaneRoadMarkTypeLineByIdx(int idx)
+LaneRoadMarkTypeLine* LaneRoadMarkType::GetLaneRoadMarkTypeLineByIdx(int idx) const
 {
     if (idx < (int)lane_roadMarkTypeLine_.size())
     {
@@ -1250,7 +1250,7 @@ void Lane::SetLaneBoundary(LaneBoundaryOSI* lane_boundary)
     lane_boundary_ = lane_boundary;
 }
 
-void LaneOffset::Print()
+void LaneOffset::Print() const
 {
     LOG("LaneOffset s %.2f a %.4f b %.2f c %.2f d %.2f length %.2f",
         s_,
@@ -1261,17 +1261,17 @@ void LaneOffset::Print()
         length_);
 }
 
-double LaneOffset::GetLaneOffset(double s)
+double LaneOffset::GetLaneOffset(double s) const
 {
     return (polynomial_.Evaluate(s - s_));
 }
 
-double LaneOffset::GetLaneOffsetPrim(double s)
+double LaneOffset::GetLaneOffsetPrim(double s) const
 {
     return (polynomial_.EvaluatePrim(s - s_));
 }
 
-void Lane::Print()
+void Lane::Print() const
 {
     LOG("Lane: %d, type: %d, level: %d", id_, type_, level_);
 
@@ -1317,7 +1317,7 @@ bool Lane::IsDriving()
     return bool(type_ & Lane::LaneType::LANE_TYPE_ANY_DRIVING);
 }
 
-LaneSection* Road::GetLaneSectionByIdx(int idx)
+LaneSection* Road::GetLaneSectionByIdx(int idx) const
 {
     if (idx >= 0 && idx < lane_section_.size())
     {
@@ -1329,7 +1329,7 @@ LaneSection* Road::GetLaneSectionByIdx(int idx)
     }
 }
 
-int Road::GetLaneSectionIdxByS(double s, int start_at)
+int Road::GetLaneSectionIdxByS(double s, int start_at) const
 {
     if (start_at < 0 || start_at > lane_section_.size() - 1)
     {
@@ -1367,7 +1367,7 @@ int Road::GetLaneSectionIdxByS(double s, int start_at)
     return (int)i;
 }
 
-int Road::GetLaneInfoByS(double s, int start_lane_section_idx, int start_lane_id, LaneInfo& lane_info, int laneTypeMask)
+int Road::GetLaneInfoByS(double s, int start_lane_section_idx, int start_lane_id, LaneInfo& lane_info, int laneTypeMask) const
 {
     lane_info.lane_section_idx_ = start_lane_section_idx;
     lane_info.lane_id_          = start_lane_id;
@@ -1450,7 +1450,7 @@ int Road::GetLaneInfoByS(double s, int start_lane_section_idx, int start_lane_id
     return 0;
 }
 
-int Road::GetConnectingLaneId(RoadLink* road_link, int fromLaneId, int connectingRoadId)
+int Road::GetConnectingLaneId(RoadLink* road_link, int fromLaneId, int connectingRoadId) const
 {
     Lane* lane;
 
@@ -1519,7 +1519,7 @@ int Road::GetConnectingLaneId(RoadLink* road_link, int fromLaneId, int connectin
     return 0;
 }
 
-double Road::GetLaneWidthByS(double s, int lane_id)
+double Road::GetLaneWidthByS(double s, int lane_id) const
 {
     LaneSection* lsec = GetLaneSectionByS(s, 0);
 
@@ -1531,7 +1531,7 @@ double Road::GetLaneWidthByS(double s, int lane_id)
     return lsec->GetWidth(s, lane_id);
 }
 
-Lane::LaneType Road::GetLaneTypeByS(double s, int lane_id)
+Lane::LaneType Road::GetLaneTypeByS(double s, int lane_id) const
 {
     LaneSection* lsec = GetLaneSectionByS(s, 0);
 
@@ -1549,7 +1549,7 @@ Lane::LaneType Road::GetLaneTypeByS(double s, int lane_id)
     return lane->GetLaneType();
 }
 
-double Road::GetSpeedByS(double s)
+double Road::GetSpeedByS(double s) const
 {
     if (type_.size() > 0)
     {
@@ -1564,7 +1564,7 @@ double Road::GetSpeedByS(double s)
     return 0;
 }
 
-Geometry* Road::GetGeometry(int idx)
+Geometry* Road::GetGeometry(int idx) const
 {
     if (idx < 0 || idx + 1 > (int)geometry_.size())
     {
@@ -1574,7 +1574,7 @@ Geometry* Road::GetGeometry(int idx)
     return geometry_[idx];
 }
 
-void LaneSection::Print()
+void LaneSection::Print() const
 {
     LOG("LaneSection: %.2f, %d lanes:", s_, (int)lane_.size());
 
@@ -1584,7 +1584,7 @@ void LaneSection::Print()
     }
 }
 
-Lane* LaneSection::GetLaneByIdx(int idx)
+Lane* LaneSection::GetLaneByIdx(int idx) const
 {
     if (idx < (int)lane_.size())
     {
@@ -1594,7 +1594,7 @@ Lane* LaneSection::GetLaneByIdx(int idx)
     return 0;
 }
 
-bool LaneSection::IsOSILaneById(int id)
+bool LaneSection::IsOSILaneById(int id) const
 {
     Lane* lane = GetLaneById(id);
     if (lane == 0)
@@ -1607,7 +1607,7 @@ bool LaneSection::IsOSILaneById(int id)
     }
 }
 
-Lane* LaneSection::GetLaneById(int id)
+Lane* LaneSection::GetLaneById(int id) const
 {
     for (size_t i = 0; i < lane_.size(); i++)
     {
@@ -1619,7 +1619,7 @@ Lane* LaneSection::GetLaneById(int id)
     return 0;
 }
 
-int LaneSection::GetLaneIdByIdx(int idx)
+int LaneSection::GetLaneIdByIdx(int idx) const
 {
     if (idx > (int)lane_.size() - 1)
     {
@@ -1632,7 +1632,7 @@ int LaneSection::GetLaneIdByIdx(int idx)
     }
 }
 
-int LaneSection::GetLaneIdxById(int id)
+int LaneSection::GetLaneIdxById(int id) const
 {
     for (int i = 0; i < (int)lane_.size(); i++)
     {
@@ -1644,7 +1644,7 @@ int LaneSection::GetLaneIdxById(int id)
     return -1;
 }
 
-int LaneSection::GetLaneGlobalIdByIdx(int idx)
+int LaneSection::GetLaneGlobalIdByIdx(int idx) const
 {
     if (idx < 0 || idx > (int)lane_.size() - 1)
     {
@@ -1656,7 +1656,7 @@ int LaneSection::GetLaneGlobalIdByIdx(int idx)
         return (lane_[idx]->GetGlobalId());
     }
 }
-int LaneSection::GetLaneGlobalIdById(int id)
+int LaneSection::GetLaneGlobalIdById(int id) const
 {
     for (size_t i = 0; i < (int)lane_.size(); i++)
     {
@@ -1668,7 +1668,7 @@ int LaneSection::GetLaneGlobalIdById(int id)
     return -1;
 }
 
-int LaneSection::GetNumberOfDrivingLanes()
+int LaneSection::GetNumberOfDrivingLanes() const
 {
     int counter = 0;
 
@@ -1682,7 +1682,7 @@ int LaneSection::GetNumberOfDrivingLanes()
     return counter;
 }
 
-int LaneSection::GetNumberOfDrivingLanesSide(int side)
+int LaneSection::GetNumberOfDrivingLanesSide(int side) const
 {
     int counter = 0;
 
@@ -1696,7 +1696,7 @@ int LaneSection::GetNumberOfDrivingLanesSide(int side)
     return counter;
 }
 
-int LaneSection::GetNUmberOfLanesRight()
+int LaneSection::GetNUmberOfLanesRight() const
 {
     int counter = 0;
 
@@ -1710,7 +1710,7 @@ int LaneSection::GetNUmberOfLanesRight()
     return counter;
 }
 
-int LaneSection::GetNUmberOfLanesLeft()
+int LaneSection::GetNUmberOfLanesLeft() const
 {
     int counter = 0;
 
@@ -1724,7 +1724,7 @@ int LaneSection::GetNUmberOfLanesLeft()
     return counter;
 }
 
-double LaneSection::GetWidth(double s, int lane_id)
+double LaneSection::GetWidth(double s, int lane_id) const
 {
     if (lane_id == 0)
     {
@@ -1753,7 +1753,7 @@ double LaneSection::GetWidth(double s, int lane_id)
     return lane_width->poly3_.Evaluate(ds);
 }
 
-double LaneSection::GetOuterOffset(double s, int lane_id)
+double LaneSection::GetOuterOffset(double s, int lane_id) const
 {
     if (lane_id == 0)
     {
@@ -1774,7 +1774,7 @@ double LaneSection::GetOuterOffset(double s, int lane_id)
     }
 }
 
-double LaneSection::GetCenterOffset(double s, int lane_id)
+double LaneSection::GetCenterOffset(double s, int lane_id) const
 {
     if (lane_id == 0)
     {
@@ -1788,7 +1788,7 @@ double LaneSection::GetCenterOffset(double s, int lane_id)
     return outer_offset - width / 2;
 }
 
-double LaneSection::GetOuterOffsetHeading(double s, int lane_id)
+double LaneSection::GetOuterOffsetHeading(double s, int lane_id) const
 {
     if (lane_id == 0)
     {
@@ -1825,7 +1825,7 @@ double LaneSection::GetOuterOffsetHeading(double s, int lane_id)
     }
 }
 
-double LaneSection::GetCenterOffsetHeading(double s, int lane_id)
+double LaneSection::GetCenterOffsetHeading(double s, int lane_id) const
 {
     int step = lane_id < 0 ? +1 : -1;
 
@@ -1863,7 +1863,7 @@ void LaneSection::AddLane(Lane* lane)
     }
 }
 
-int LaneSection::GetConnectingLaneId(int incoming_lane_id, LinkType link_type)
+int LaneSection::GetConnectingLaneId(int incoming_lane_id, LinkType link_type) const
 {
     int id = incoming_lane_id;
 
@@ -1892,7 +1892,7 @@ int LaneSection::GetConnectingLaneId(int incoming_lane_id, LinkType link_type)
     return id;
 }
 
-double LaneSection::GetWidthBetweenLanes(int lane_id1, int lane_id2, double s)
+double LaneSection::GetWidthBetweenLanes(int lane_id1, int lane_id2, double s) const
 {
     double lanewidth = (std::fabs(GetCenterOffset(s, lane_id1)) - std::fabs(GetCenterOffset(s, lane_id2)));
 
@@ -1900,7 +1900,7 @@ double LaneSection::GetWidthBetweenLanes(int lane_id1, int lane_id2, double s)
 }
 
 // Offset from lane1 to lane2 in direction of reference line
-double LaneSection::GetOffsetBetweenLanes(int lane_id1, int lane_id2, double s)
+double LaneSection::GetOffsetBetweenLanes(int lane_id1, int lane_id2, double s) const
 {
     double laneCenter1 = GetCenterOffset(s, lane_id1) * SIGN(lane_id1);
     double laneCenter2 = GetCenterOffset(s, lane_id2) * SIGN(lane_id2);
@@ -1908,7 +1908,7 @@ double LaneSection::GetOffsetBetweenLanes(int lane_id1, int lane_id2, double s)
 }
 
 // Offset from closest left road mark to current position
-RoadMarkInfo Lane::GetRoadMarkInfoByS(int track_id, int lane_id, double s)
+RoadMarkInfo Lane::GetRoadMarkInfoByS(int track_id, int lane_id, double s) const
 {
     Position*             pos  = new roadmanager::Position();
     Road*                 road = pos->GetRoadById(track_id);
@@ -2080,7 +2080,7 @@ bool RoadLink::operator==(RoadLink& rhs)
             rhs.contact_point_type_ == contact_point_type_);
 }
 
-void RoadLink::Print()
+void RoadLink::Print() const
 {
     cout << "RoadLink type: " << type_ << " id: " << element_id_ << " element type: " << element_type_
          << " contact point type: " << contact_point_type_ << endl;
@@ -2136,7 +2136,7 @@ Road::~Road()
     object_.clear();
 }
 
-void Road::Print()
+void Road::Print() const
 {
     LOG("Road id: %d length: %.2f", id_, GetLength());
     cout << "Geometries:" << endl;
@@ -2213,7 +2213,7 @@ void Road::AddSuperElevation(Elevation* super_elevation)
     super_elevation_profile_.push_back((Elevation*)super_elevation);
 }
 
-Elevation* Road::GetElevation(int idx)
+Elevation* Road::GetElevation(int idx) const
 {
     if (idx < 0 || idx >= elevation_profile_.size())
     {
@@ -2223,7 +2223,7 @@ Elevation* Road::GetElevation(int idx)
     return elevation_profile_[idx];
 }
 
-Elevation* Road::GetSuperElevation(int idx)
+Elevation* Road::GetSuperElevation(int idx) const
 {
     if (idx < 0 || idx >= super_elevation_profile_.size())
     {
@@ -2248,12 +2248,12 @@ void Road::AddSignal(Signal* signal)
     signal_.push_back((Signal*)signal);
 }
 
-int Road::GetNumberOfSignals()
+int Road::GetNumberOfSignals() const
 {
     return (int)signal_.size();
 }
 
-Signal* Road::GetSignal(int idx)
+Signal* Road::GetSignal(int idx) const
 {
     if (idx < 0 || idx >= signal_.size())
     {
@@ -2269,7 +2269,7 @@ void Road::AddObject(RMObject* object)
     object_.push_back(object);
 }
 
-RMObject* Road::GetRoadObject(int idx)
+RMObject* Road::GetRoadObject(int idx) const
 {
     if (idx < 0 || idx >= object_.size())
     {
@@ -2384,7 +2384,7 @@ RMObject::ObjectType RMObject::Str2Type(std::string type)
     return RMObject::ObjectType::NONE;
 }
 
-double Road::GetLaneOffset(double s)
+double Road::GetLaneOffset(double s) const
 {
     int i = 0;
 
@@ -2403,7 +2403,7 @@ double Road::GetLaneOffset(double s)
     return (lane_offset_[i]->GetLaneOffset(s));
 }
 
-double Road::GetLaneOffsetPrim(double s)
+double Road::GetLaneOffsetPrim(double s) const
 {
     int i = 0;
 
@@ -2422,7 +2422,7 @@ double Road::GetLaneOffsetPrim(double s)
     return (lane_offset_[i]->GetLaneOffsetPrim(s));
 }
 
-int Road::GetNumberOfLanes(double s)
+int Road::GetNumberOfLanes(double s) const
 {
     LaneSection* lsec = GetLaneSectionByS(s);
 
@@ -2434,7 +2434,7 @@ int Road::GetNumberOfLanes(double s)
     return 0;
 }
 
-int Road::GetNumberOfDrivingLanes(double s)
+int Road::GetNumberOfDrivingLanes(double s) const
 {
     LaneSection* lsec = GetLaneSectionByS(s);
 
@@ -2446,7 +2446,7 @@ int Road::GetNumberOfDrivingLanes(double s)
     return 0;
 }
 
-Lane* Road::GetDrivingLaneByIdx(double s, int idx)
+Lane* Road::GetDrivingLaneByIdx(double s, int idx) const
 {
     int count = 0;
 
@@ -2466,7 +2466,7 @@ Lane* Road::GetDrivingLaneByIdx(double s, int idx)
     return 0;
 }
 
-Lane* Road::GetDrivingLaneSideByIdx(double s, int side, int idx)
+Lane* Road::GetDrivingLaneSideByIdx(double s, int side, int idx) const
 {
     int count = 0;
 
@@ -2487,7 +2487,7 @@ Lane* Road::GetDrivingLaneSideByIdx(double s, int side, int idx)
     return 0;
 }
 
-Lane* Road::GetDrivingLaneById(double s, int id)
+Lane* Road::GetDrivingLaneById(double s, int id) const
 {
     LaneSection* ls   = GetLaneSectionByS(s);
     Lane*        lane = ls->GetLaneById(id);
@@ -2499,7 +2499,7 @@ Lane* Road::GetDrivingLaneById(double s, int id)
     return 0;
 }
 
-int Road::GetNumberOfDrivingLanesSide(double s, int side)
+int Road::GetNumberOfDrivingLanesSide(double s, int side) const
 {
     int i;
 
@@ -2514,7 +2514,7 @@ int Road::GetNumberOfDrivingLanesSide(double s, int side)
     return (lane_section_[i]->GetNumberOfDrivingLanesSide(side));
 }
 
-int Road::GetConnectedLaneIdAtS(int lane_id, double s_start, double s_target)
+int Road::GetConnectedLaneIdAtS(int lane_id, double s_start, double s_target) const
 {
     int connected_lane_id = 0;
 
@@ -2574,7 +2574,7 @@ int Road::GetConnectedLaneIdAtS(int lane_id, double s_start, double s_target)
     return connected_lane_id;
 }
 
-bool Road::IsDirectlyConnected(Road* road, LinkType link_type, ContactPointType* contact_point, int fromLaneId)
+bool Road::IsDirectlyConnected(Road* road, LinkType link_type, ContactPointType* contact_point, int fromLaneId) const
 {
     if (road == nullptr)
     {
@@ -2634,17 +2634,17 @@ bool Road::IsDirectlyConnected(Road* road, LinkType link_type, ContactPointType*
     return false;
 }
 
-bool Road::IsSuccessor(Road* road, ContactPointType* contact_point, int fromLaneId)
+bool Road::IsSuccessor(Road* road, ContactPointType* contact_point, int fromLaneId) const
 {
     return IsDirectlyConnected(road, LinkType::SUCCESSOR, contact_point, fromLaneId) != 0;
 }
 
-bool Road::IsPredecessor(Road* road, ContactPointType* contact_point, int fromLaneId)
+bool Road::IsPredecessor(Road* road, ContactPointType* contact_point, int fromLaneId) const
 {
     return IsDirectlyConnected(road, LinkType::PREDECESSOR, contact_point, fromLaneId) != 0;
 }
 
-bool Road::IsDirectlyConnected(Road* road, double* curvature, int fromLaneId)
+bool Road::IsDirectlyConnected(Road* road, double* curvature, int fromLaneId) const
 {
     ContactPointType contact_point;
 
@@ -2677,7 +2677,7 @@ bool Road::IsDirectlyConnected(Road* road, double* curvature, int fromLaneId)
     return false;
 }
 
-double Road::GetWidth(double s, int side, int laneTypeMask)
+double Road::GetWidth(double s, int side, int laneTypeMask) const
 {
     double offset0 = 0;
     double offset1 = 0;
@@ -2756,7 +2756,7 @@ void Road::AddLaneOffset(LaneOffset* lane_offset)
     lane_offset_.push_back((LaneOffset*)lane_offset);
 }
 
-double Road::GetCenterOffset(double s, int lane_id)
+double Road::GetCenterOffset(double s, int lane_id) const
 {
     // First find out what lane section
     LaneSection* lane_section = GetLaneSectionByS(s);
@@ -2768,7 +2768,7 @@ double Road::GetCenterOffset(double s, int lane_id)
     return 0.0;
 }
 
-Road::RoadTypeEntry* Road::GetRoadType(int idx)
+Road::RoadTypeEntry* Road::GetRoadType(int idx) const
 {
     if (type_.size() > 0)
     {
@@ -2780,7 +2780,7 @@ Road::RoadTypeEntry* Road::GetRoadType(int idx)
     }
 }
 
-RoadLink* Road::GetLink(LinkType type)
+RoadLink* Road::GetLink(LinkType type) const
 {
     for (size_t i = 0; i < link_.size(); i++)
     {
@@ -2805,7 +2805,7 @@ void Road::AddLaneSection(LaneSection* lane_section)
     lane_section_.push_back((LaneSection*)lane_section);
 }
 
-bool Road::GetZAndPitchByS(double s, double* z, double* z_prim, double* z_primPrim, double* pitch, int* index)
+bool Road::GetZAndPitchByS(double s, double* z, double* z_prim, double* z_primPrim, double* pitch, int* index) const
 {
     if (GetNumberOfElevations() > 0)
     {
@@ -2898,7 +2898,7 @@ bool Road::UpdateZAndRollBySAndT(double s, double t, double* z, double* roadSupe
     return false;
 }
 
-Road* OpenDrive::GetRoadById(int id)
+Road* OpenDrive::GetRoadById(int id) const
 {
     for (size_t i = 0; i < road_.size(); i++)
     {
@@ -2910,7 +2910,7 @@ Road* OpenDrive::GetRoadById(int id)
     return 0;
 }
 
-Road* OpenDrive::GetRoadByIdx(int idx)
+Road* OpenDrive::GetRoadByIdx(int idx) const
 {
     if (idx >= 0 && idx < (int)road_.size())
     {
@@ -2922,7 +2922,7 @@ Road* OpenDrive::GetRoadByIdx(int idx)
     }
 }
 
-Geometry* OpenDrive::GetGeometryByIdx(int road_idx, int geom_idx)
+Geometry* OpenDrive::GetGeometryByIdx(int road_idx, int geom_idx) const
 {
     if (road_idx >= 0 && road_idx < (int)road_.size())
     {
@@ -2934,7 +2934,7 @@ Geometry* OpenDrive::GetGeometryByIdx(int road_idx, int geom_idx)
     }
 }
 
-Junction* OpenDrive::GetJunctionById(int id)
+Junction* OpenDrive::GetJunctionById(int id) const
 {
     for (size_t i = 0; i < junction_.size(); i++)
     {
@@ -2946,7 +2946,7 @@ Junction* OpenDrive::GetJunctionById(int id)
     return 0;
 }
 
-Junction* OpenDrive::GetJunctionByIdx(int idx)
+Junction* OpenDrive::GetJunctionByIdx(int idx) const
 {
     if (idx >= 0 && idx < (int)junction_.size())
     {
@@ -4404,7 +4404,7 @@ void Connection::AddJunctionLaneLink(int from, int to)
     lane_link_.push_back(new JunctionLaneLink(from, to));
 }
 
-int Connection::GetConnectingLaneId(int incoming_lane_id)
+int Connection::GetConnectingLaneId(int incoming_lane_id) const
 {
     for (size_t i = 0; i < lane_link_.size(); i++)
     {
@@ -4416,7 +4416,7 @@ int Connection::GetConnectingLaneId(int incoming_lane_id)
     return 0;
 }
 
-void Connection::Print()
+void Connection::Print() const
 {
     LOG("Connection: incoming %d connecting %d", incoming_road_->GetId(), connecting_road_->GetId());
     for (size_t i = 0; i < lane_link_.size(); i++)
@@ -4433,7 +4433,7 @@ Junction::~Junction()
     }
 }
 
-int Junction::GetNumberOfRoadConnections(int roadId, int laneId)
+int Junction::GetNumberOfRoadConnections(int roadId, int laneId) const
 {
     int counter = 0;
 
@@ -4455,7 +4455,7 @@ int Junction::GetNumberOfRoadConnections(int roadId, int laneId)
     return counter;
 }
 
-LaneRoadLaneConnection Junction::GetRoadConnectionByIdx(int roadId, int laneId, int idx, int laneTypeMask)
+LaneRoadLaneConnection Junction::GetRoadConnectionByIdx(int roadId, int laneId, int idx, int laneTypeMask) const
 {
     int                    counter = 0;
     LaneRoadLaneConnection lane_road_lane_connection;
@@ -4521,7 +4521,7 @@ void Junction::SetGlobalId()
     global_id_ = GetNewGlobalLaneId();
 }
 
-bool Junction::IsOsiIntersection()
+bool Junction::IsOsiIntersection() const
 {
     if (connection_.size() > 0 && connection_[0]->GetIncomingRoad() && connection_[0]->GetIncomingRoad() &&
         connection_[0]->GetIncomingRoad()->GetRoadType(0) != 0)
@@ -4542,7 +4542,7 @@ bool Junction::IsOsiIntersection()
     }
 }
 
-int Junction::GetNoConnectionsFromRoadId(int incomingRoadId)
+int Junction::GetNoConnectionsFromRoadId(int incomingRoadId) const
 {
     int counter = 0;
 
@@ -4558,7 +4558,7 @@ int Junction::GetNoConnectionsFromRoadId(int incomingRoadId)
     return counter;
 }
 
-int Junction::GetConnectingRoadIdFromIncomingRoadId(int incomingRoadId, int index)
+int Junction::GetConnectingRoadIdFromIncomingRoadId(int incomingRoadId, int index) const
 {
     int counter = 0;
 
@@ -4580,7 +4580,7 @@ int Junction::GetConnectingRoadIdFromIncomingRoadId(int incomingRoadId, int inde
     return -1;
 }
 
-void Junction::Print()
+void Junction::Print() const
 {
     LOG("Junction %d %s:", id_, name_.c_str());
 
@@ -4600,7 +4600,7 @@ JunctionController* Junction::GetJunctionControllerByIdx(int index)
     return 0;
 }
 
-Road* Junction::GetRoadAtOtherEndOfConnectingRoad(Road* connecting_road, Road* incoming_road)
+Road* Junction::GetRoadAtOtherEndOfConnectingRoad(Road* connecting_road, Road* incoming_road) const
 {
     if (connecting_road->GetJunction() == 0)
     {
@@ -5055,7 +5055,7 @@ OpenDrive::~OpenDrive()
     Clear();
 }
 
-int OpenDrive::GetTrackIdxById(int id)
+int OpenDrive::GetTrackIdxById(int id) const
 {
     for (int i = 0; i < (int)road_.size(); i++)
     {
@@ -5068,7 +5068,7 @@ int OpenDrive::GetTrackIdxById(int id)
     return -1;
 }
 
-int OpenDrive::GetTrackIdByIdx(int idx)
+int OpenDrive::GetTrackIdByIdx(int idx) const
 {
     if (idx >= 0 && idx < (int)road_.size())
     {
@@ -5078,7 +5078,7 @@ int OpenDrive::GetTrackIdByIdx(int idx)
     return 0;
 }
 
-bool OpenDrive::IsIndirectlyConnected(int road1_id, int road2_id, int*& connecting_road_id, int*& connecting_lane_id, int lane1_id, int lane2_id)
+bool OpenDrive::IsIndirectlyConnected(int road1_id, int road2_id, int*& connecting_road_id, int*& connecting_lane_id, int lane1_id, int lane2_id) const
 {
     Road*     road1 = GetRoadById(road1_id);
     Road*     road2 = GetRoadById(road2_id);
@@ -5473,7 +5473,7 @@ int OpenDrive::CheckConnections()
     return counter;
 }
 
-void OpenDrive::Print()
+void OpenDrive::Print() const
 {
     LOG("Roads:");
     for (size_t i = 0; i < road_.size(); i++)
@@ -5493,7 +5493,7 @@ GeoReference* OpenDrive::GetGeoReference()
     return &geo_ref_;
 }
 
-std::string OpenDrive::GetGeoReferenceAsString()
+std::string OpenDrive::GetGeoReferenceAsString() const
 {
     std::ostringstream out;
     if (!std::isnan(geo_ref_.lat_0_) && !std::isnan(geo_ref_.lon_0_))
@@ -5829,7 +5829,7 @@ OpenDrive* Position::GetOpenDrive()
     return &od;
 }
 
-bool OpenDrive::CheckLaneOSIRequirement(std::vector<double> x0, std::vector<double> y0, std::vector<double> x1, std::vector<double> y1)
+bool OpenDrive::CheckLaneOSIRequirement(std::vector<double> x0, std::vector<double> y0, std::vector<double> x1, std::vector<double> y1) const
 {
     double x0_tan_diff, y0_tan_diff, x1_tan_diff, y1_tan_diff;
     x0_tan_diff = x0[2] - x0[0];
@@ -6675,7 +6675,7 @@ bool OpenDrive::SetRoadOSI()
     return false;
 }
 
-int LaneSection::GetClosestLaneIdx(double s, double t, int side, double& offset, bool noZeroWidth, int laneTypeMask)
+int LaneSection::GetClosestLaneIdx(double s, double t, int side, double& offset, bool noZeroWidth, int laneTypeMask) const
 {
     double min_offset         = t;  // Initial offset relates to reference line
     int    candidate_lane_idx = -1;
@@ -8773,7 +8773,7 @@ void Position::EvaluateOrientation()
     }
 }
 
-double Position::GetCurvature()
+double Position::GetCurvature() const
 {
     Geometry* geom = GetOpenDrive()->GetGeometryByIdx(track_idx_, geometry_idx_);
 
@@ -8813,7 +8813,7 @@ double Position::GetHRoadInDrivingDirection() const
     return GetAngleSum(GetHRoad(), GetDrivingDirectionRelativeRoad() < 0 ? M_PI : 0.0);
 }
 
-double Position::GetPRoadInDrivingDirection()
+double Position::GetPRoadInDrivingDirection() const
 {
     return GetPRoad() * GetDrivingDirectionRelativeRoad();
 }
@@ -8823,7 +8823,7 @@ double Position::GetHRelativeDrivingDirection() const
     return GetAngleDifference(h_, GetDrivingDirection());
 }
 
-double Position::GetSpeedLimit()
+double Position::GetSpeedLimit() const
 {
     double speed_limit = 70 / 3.6;  // some default speed
     Road*  road        = GetOpenDrive()->GetRoadByIdx(track_idx_);
@@ -8869,7 +8869,7 @@ double Position::GetDrivingDirection() const
     return (h);
 }
 
-double Position::GetVelLat()
+double Position::GetVelLat() const
 {
     double vlat  = 0.0;
     double vlong = 0.0;
@@ -8878,7 +8878,7 @@ double Position::GetVelLat()
     return vlat;
 }
 
-double Position::GetVelLong()
+double Position::GetVelLong() const
 {
     double vlat  = 0.0;
     double vlong = 0.0;
@@ -8887,12 +8887,12 @@ double Position::GetVelLong()
     return vlong;
 }
 
-void Position::GetVelLatLong(double& vlat, double& vlong)
+void Position::GetVelLatLong(double& vlat, double& vlong) const
 {
     RotateVec2D(GetVelX(), GetVelY(), -GetH(), vlong, vlat);
 }
 
-double Position::GetAccLat()
+double Position::GetAccLat() const
 {
     double alat  = 0.0;
     double along = 0.0;
@@ -8901,7 +8901,7 @@ double Position::GetAccLat()
     return alat;
 }
 
-double Position::GetAccLong()
+double Position::GetAccLong() const
 {
     double alat  = 0.0;
     double along = 0.0;
@@ -8910,12 +8910,12 @@ double Position::GetAccLong()
     return along;
 }
 
-void Position::GetAccLatLong(double& alat, double& along)
+void Position::GetAccLatLong(double& alat, double& along) const
 {
     RotateVec2D(GetAccX(), GetAccY(), -GetH(), along, alat);
 }
 
-double Position::GetVelT()
+double Position::GetVelT() const
 {
     double vs = 0.0;
     double vt = 0.0;
@@ -8924,7 +8924,7 @@ double Position::GetVelT()
     return vt;
 }
 
-double Position::GetVelS()
+double Position::GetVelS() const
 {
     double vs = 0.0;
     double vt = 0.0;
@@ -8933,12 +8933,12 @@ double Position::GetVelS()
     return vs;
 }
 
-void Position::GetVelTS(double& vt, double& vs)
+void Position::GetVelTS(double& vt, double& vs) const
 {
     RotateVec2D(GetVelX(), GetVelY(), -GetHRoad(), vs, vt);
 }
 
-double Position::GetAccT()
+double Position::GetAccT() const
 {
     double at = 0.0;
     double as = 0.0;
@@ -8947,7 +8947,7 @@ double Position::GetAccT()
     return at;
 }
 
-double Position::GetAccS()
+double Position::GetAccS() const
 {
     double at = 0.0;
     double as = 0.0;
@@ -8956,12 +8956,12 @@ double Position::GetAccS()
     return as;
 }
 
-void Position::GetAccTS(double& at, double& as)
+void Position::GetAccTS(double& at, double& as) const
 {
     RotateVec2D(GetAccX(), GetAccY(), -GetHRoad(), as, at);
 }
 
-double Position::GetAcc()
+double Position::GetAcc() const
 {
     // Find out x component of acceleration aligned with object coordinate system
     double x = GetAccX() * cos(-GetH()) - GetAccY() * sin(-GetH());
@@ -8993,22 +8993,22 @@ void Position::CopyRMPos(Position* from)
     snapToLaneTypes_ = tmp_pos.snapToLaneTypes_;
 }
 
-void Position::PrintTrackPos()
+void Position::PrintTrackPos() const
 {
     LOG("	Track pos: (road_id %d, s %.2f, t %.2f, h %.2f)", track_id_, s_, t_, h_);
 }
 
-void Position::PrintLanePos()
+void Position::PrintLanePos() const
 {
     LOG("	Lane pos: (road_id %d, lane_id %d, s %.2f, offset %.2f, h %.2f)", track_id_, lane_id_, s_, offset_, h_);
 }
 
-void Position::PrintInertialPos()
+void Position::PrintInertialPos() const
 {
     LOG("	Inertial pos: (x %.2f, y %.2f, z %.2f, h %.2f, p %.2f, r %.2f)", x_, y_, z_, h_, p_, r_);
 }
 
-void Position::Print()
+void Position::Print() const
 {
     LOG("Pos(%.2f, %.2f, %.2f) Rot(%.2f, %.2f, %.2f) roadId %d laneId %d offset %.2f t %.2f",
         GetX(),
@@ -9023,12 +9023,12 @@ void Position::Print()
         GetT());
 }
 
-void Position::PrintXY()
+void Position::PrintXY() const
 {
     LOG("%.2f, %.2f", x_, y_);
 }
 
-bool Position::IsOffRoad()
+bool Position::IsOffRoad() const
 {
     Road* road = GetOpenDrive()->GetRoadByIdx(track_idx_);
     if (road)
@@ -9043,7 +9043,7 @@ bool Position::IsOffRoad()
     return false;
 }
 
-bool Position::IsInJunction()
+bool Position::IsInJunction() const
 {
     Road* road = GetOpenDrive()->GetRoadByIdx(track_idx_);
     if (road)
@@ -9061,7 +9061,7 @@ int Position::GetNumberOfRoadsOverlapping()
     return static_cast<int>(overlapping_roads.size());
 }
 
-int Position::GetOverlappingRoadId(int index)
+int Position::GetOverlappingRoadId(int index) const
 {
     if (overlapping_roads.size() == 0 || index >= overlapping_roads.size() || index < 0)
     {
@@ -9213,7 +9213,7 @@ bool Position::Delta(Position* pos_b, PositionDiff& diff, bool bothDirections, d
     return found;
 }
 
-int Position::Distance(Position* pos_b, CoordinateSystem cs, RelativeDistanceType relDistType, double& dist, double maxDist)
+int Position::Distance(Position* pos_b, CoordinateSystem cs, RelativeDistanceType relDistType, double& dist, double maxDist) const
 {
     // Handle/convert depricated value
     if (relDistType == RelativeDistanceType::REL_DIST_CARTESIAN)
@@ -9266,7 +9266,7 @@ int Position::Distance(Position* pos_b, CoordinateSystem cs, RelativeDistanceTyp
     return 0;
 }
 
-int Position::Distance(double x, double y, CoordinateSystem cs, RelativeDistanceType relDistType, double& dist, double maxDist)
+int Position::Distance(double x, double y, CoordinateSystem cs, RelativeDistanceType relDistType, double& dist, double maxDist) const
 {
     // Handle/convert depricated value
     if (relDistType == RelativeDistanceType::REL_DIST_CARTESIAN)
@@ -9320,7 +9320,7 @@ int Position::Distance(double x, double y, CoordinateSystem cs, RelativeDistance
     return 0;
 }
 
-bool Position::IsAheadOf(Position target_position)
+bool Position::IsAheadOf(Position target_position) const
 {
     // Calculate diff vector from current to target
     double diff_x, diff_y;
@@ -9337,7 +9337,7 @@ bool Position::IsAheadOf(Position target_position)
     return (diff_x0 < 0);
 }
 
-int Position::GetRoadLaneInfo(RoadLaneInfo* data)
+int Position::GetRoadLaneInfo(RoadLaneInfo* data) const
 {
     double curvature = GetCurvature();
     if (fabs(curvature) > SMALL_NUMBER)
@@ -9376,7 +9376,7 @@ int Position::GetRoadLaneInfo(RoadLaneInfo* data)
     return 0;
 }
 
-int Position::GetRoadLaneInfo(double lookahead_distance, RoadLaneInfo* data, LookAheadMode lookAheadMode)
+int Position::GetRoadLaneInfo(double lookahead_distance, RoadLaneInfo* data, LookAheadMode lookAheadMode) const
 {
     Position target(*this);  // Make a copy of current position
 
@@ -9405,7 +9405,7 @@ int Position::GetRoadLaneInfo(double lookahead_distance, RoadLaneInfo* data, Loo
     return 0;
 }
 
-int Position::CalcProbeTarget(Position* target, RoadProbeInfo* data)
+int Position::CalcProbeTarget(Position* target, RoadProbeInfo* data) const
 {
     int retval = target->GetRoadLaneInfo(&data->road_lane_info);
 
@@ -9443,7 +9443,7 @@ int Position::CalcProbeTarget(Position* target, RoadProbeInfo* data)
     return retval;
 }
 
-Position::ReturnCode Position::GetProbeInfo(double lookahead_distance, RoadProbeInfo* data, LookAheadMode lookAheadMode)
+Position::ReturnCode Position::GetProbeInfo(double lookahead_distance, RoadProbeInfo* data, LookAheadMode lookAheadMode) const
 {
     ReturnCode retval = ReturnCode::OK;
 
@@ -9496,7 +9496,7 @@ Position::ReturnCode Position::GetProbeInfo(double lookahead_distance, RoadProbe
     return retval;
 }
 
-Position::ReturnCode Position::GetProbeInfo(Position* target_pos, RoadProbeInfo* data)
+Position::ReturnCode Position::GetProbeInfo(Position* target_pos, RoadProbeInfo* data) const
 {
     if (CalcProbeTarget(target_pos, data) != 0)
     {
@@ -9542,7 +9542,7 @@ int Position::GetLaneId() const
     return lane_id_;
 }
 
-int Position::GetLaneGlobalId()
+int Position::GetLaneGlobalId() const
 {
     Road* road = GetRoadById(GetTrackId());
     if (road == 0)
@@ -9614,7 +9614,7 @@ double Position::GetT() const
     return t_;
 }
 
-double Position::GetOffset()
+double Position::GetOffset() const
 {
     if (rel_pos_ && rel_pos_ != this && type_ == PositionType::RELATIVE_ROAD)
     {
@@ -9810,7 +9810,7 @@ double Position::GetHRelative() const
     return h_relative_;
 }
 
-double Position::GetP()
+double Position::GetP() const
 {
     if (!rel_pos_ || rel_pos_ == this)
     {
@@ -9846,7 +9846,7 @@ double Position::GetP()
     return p_;
 }
 
-double Position::GetPRelative()
+double Position::GetPRelative() const
 {
     if (!rel_pos_ || rel_pos_ == this)
     {
@@ -9882,7 +9882,7 @@ double Position::GetPRelative()
     return p_relative_;
 }
 
-double Position::GetR()
+double Position::GetR() const
 {
     if (!rel_pos_ || rel_pos_ == this)
     {
@@ -9918,7 +9918,7 @@ double Position::GetR()
     return r_;
 }
 
-double Position::GetRRelative()
+double Position::GetRRelative() const
 {
     if (!rel_pos_ || rel_pos_ == this)
     {
@@ -9977,7 +9977,7 @@ int Position::SetRoutePosition(Position* position)
     return -1;
 }
 
-double Position::GetRouteS()
+double Position::GetRouteS() const
 {
     if (!route_ || !route_->IsValid())
     {
@@ -11499,7 +11499,7 @@ Position* Route::GetWaypoint(int index)
     return &minimal_waypoints_[index];
 }
 
-Road* Route::GetRoadAtOtherEndOfConnectingRoad(Road* incoming_road)
+Road* Route::GetRoadAtOtherEndOfConnectingRoad(Road* incoming_road) const
 {
     Road*     connecting_road = Position::GetOpenDrive()->GetRoadById(GetTrackId());
     Junction* junction        = Position::GetOpenDrive()->GetJunctionById(connecting_road->GetJunction());
@@ -11586,7 +11586,7 @@ void Route::setName(std::string name)
     this->name_ = name;
 }
 
-std::string Route::getName()
+std::string Route::getName() const
 {
     return name_;
 }

--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.hpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.hpp
@@ -54,29 +54,29 @@ namespace roadmanager
         {
             d_ = d;
         }
-        double GetA()
+        double GetA() const
         {
             return a_;
         }
-        double GetB()
+        double GetB() const
         {
             return b_;
         }
-        double GetC()
+        double GetC() const
         {
             return c_;
         }
-        double GetD()
+        double GetD() const
         {
             return d_;
         }
-        double GetPscale()
+        double GetPscale() const
         {
             return p_scale_;
         }
-        double Evaluate(double s);
-        double EvaluatePrim(double s);
-        double EvaluatePrimPrim(double s);
+        double Evaluate(double s) const;
+        double EvaluatePrim(double s) const;
+        double EvaluatePrimPrim(double s) const;
 
     private:
         double a_;
@@ -113,11 +113,11 @@ namespace roadmanager
             return point_;
         }
         PointStruct &GetPoint(int i);
-        double       GetXfromIdx(int i);
-        double       GetYfromIdx(int i);
-        double       GetZfromIdx(int i);
-        int          GetNumOfOSIPoints();
-        double       GetLength();
+        double       GetXfromIdx(int i) const;
+        double       GetYfromIdx(int i) const;
+        double       GetZfromIdx(int i) const;
+        int          GetNumOfOSIPoints() const;
+        double       GetLength() const;
 
     private:
         std::vector<PointStruct> point_;
@@ -157,15 +157,15 @@ namespace roadmanager
         {
         }
 
-        GeometryType GetType()
+        GeometryType GetType() const
         {
             return type_;
         }
-        double GetLength()
+        double GetLength() const
         {
             return length_;
         }
-        virtual double GetX()
+        virtual double GetX() const
         {
             return x_;
         }
@@ -173,7 +173,7 @@ namespace roadmanager
         {
             x_ = x;
         }
-        virtual double GetY()
+        virtual double GetY() const
         {
             return y_;
         }
@@ -181,7 +181,7 @@ namespace roadmanager
         {
             y_ = y;
         }
-        virtual double GetHdg()
+        virtual double GetHdg() const
         {
             return GetAngleInInterval2PI(hdg_);
         }
@@ -189,13 +189,13 @@ namespace roadmanager
         {
             hdg_ = hdg;
         }
-        double GetS()
+        double GetS() const
         {
             return s_;
         }
-        virtual double EvaluateCurvatureDS(double ds) = 0;
-        virtual void   Print();
-        virtual void   EvaluateDS(double ds, double *x, double *y, double *h);
+        virtual double EvaluateCurvatureDS(double ds) const = 0;
+        virtual void   Print() const;
+        virtual void   EvaluateDS(double ds, double *x, double *y, double *h) const;
 
     protected:
         double       s_;
@@ -217,9 +217,9 @@ namespace roadmanager
         }
         ~Line(){};
 
-        void   Print();
-        void   EvaluateDS(double ds, double *x, double *y, double *h);
-        double EvaluateCurvatureDS(double ds)
+        void   Print() const;
+        void   EvaluateDS(double ds, double *x, double *y, double *h) const;
+        double EvaluateCurvatureDS(double ds) const
         {
             (void)ds;
             return 0;
@@ -241,18 +241,18 @@ namespace roadmanager
         {
         }
 
-        double EvaluateCurvatureDS(double ds)
+        double EvaluateCurvatureDS(double ds) const
         {
             (void)ds;
             return curvature_;
         }
-        double GetRadius();
-        double GetCurvature()
+        double GetRadius() const;
+        double GetCurvature() const
         {
             return curvature_;
         }
-        void Print();
-        void EvaluateDS(double ds, double *x, double *y, double *h);
+        void Print() const;
+        void EvaluateDS(double ds, double *x, double *y, double *h) const;
 
     private:
         double curvature_;
@@ -278,31 +278,31 @@ namespace roadmanager
             }
         };
 
-        double GetCurvStart()
+        double GetCurvStart() const
         {
             return curv_start_;
         }
-        double GetCurvEnd()
+        double GetCurvEnd() const
         {
             return curv_end_;
         }
-        double GetX0()
+        double GetX0() const
         {
             return x0_;
         }
-        double GetY0()
+        double GetY0() const
         {
             return y0_;
         }
-        double GetH0()
+        double GetH0() const
         {
             return h0_;
         }
-        double GetS0()
+        double GetS0() const
         {
             return s0_;
         }
-        double GetCDot()
+        double GetCDot() const
         {
             return c_dot_;
         }
@@ -326,9 +326,9 @@ namespace roadmanager
         {
             c_dot_ = c_dot;
         }
-        void   Print();
-        void   EvaluateDS(double ds, double *x, double *y, double *h);
-        double EvaluateCurvatureDS(double ds);
+        void   Print() const;
+        void   EvaluateDS(double ds, double *x, double *y, double *h) const;
+        double EvaluateCurvatureDS(double ds) const;
         void   SetX(double x);
         void   SetY(double y);
         void   SetHdg(double h);
@@ -359,23 +359,23 @@ namespace roadmanager
         {
             umax_ = umax;
         }
-        double GetUMax()
+        double GetUMax() const
         {
             return umax_;
         }
-        void       Print();
-        Polynomial GetPoly3()
+        void       Print() const;
+        Polynomial GetPoly3() const
         {
             return poly3_;
         }
-        void   EvaluateDS(double ds, double *x, double *y, double *h);
-        double EvaluateCurvatureDS(double ds);
+        void   EvaluateDS(double ds, double *x, double *y, double *h) const;
+        double EvaluateCurvatureDS(double ds) const;
 
         Polynomial poly3_;
 
     private:
         double umax_;
-        void   EvaluateDSLocal(double ds, double &u, double &v);
+        void   EvaluateDSLocal(double ds, double &u, double &v) const;
     };
 
     class ParamPoly3 : public Geometry
@@ -413,20 +413,20 @@ namespace roadmanager
         }
         ~ParamPoly3(){};
 
-        void       Print();
-        Polynomial GetPoly3U()
+        void       Print() const;
+        Polynomial GetPoly3U() const
         {
             return poly3U_;
         }
-        Polynomial GetPoly3V()
+        Polynomial GetPoly3V() const
         {
             return poly3V_;
         }
-        void   EvaluateDS(double ds, double *x, double *y, double *h);
-        double EvaluateCurvatureDS(double ds);
+        void   EvaluateDS(double ds, double *x, double *y, double *h) const;
+        double EvaluateCurvatureDS(double ds) const;
         void   calcS2PMap(PRangeType p_range);
         double s2p_map_[PARAMPOLY3_STEPS + 1][2];
-        double S2P(double s);
+        double S2P(double s) const;
 
         Polynomial poly3U_;
         Polynomial poly3V_;
@@ -444,7 +444,7 @@ namespace roadmanager
         }
         ~Elevation(){};
 
-        double GetS()
+        double GetS() const
         {
             return s_;
         }
@@ -452,11 +452,11 @@ namespace roadmanager
         {
             length_ = length;
         }
-        double GetLength()
+        double GetLength() const
         {
             return length_;
         }
-        void Print();
+        void Print() const;
 
         Polynomial poly3_;
 
@@ -479,15 +479,15 @@ namespace roadmanager
         {
         }
 
-        LinkType GetType()
+        LinkType GetType() const
         {
             return type_;
         }
-        int GetId()
+        int GetId() const
         {
             return id_;
         }
-        void Print();
+        void Print() const;
 
     private:
         LinkType type_;
@@ -502,11 +502,11 @@ namespace roadmanager
             poly3_.Set(a, b, c, d);
         }
 
-        double GetSOffset()
+        double GetSOffset() const
         {
             return s_offset_;
         }
-        void Print();
+        void Print() const;
 
         Polynomial poly3_;
 
@@ -522,7 +522,7 @@ namespace roadmanager
         }
         ~LaneBoundaryOSI(){};
         void SetGlobalId();
-        int  GetGlobalId()
+        int  GetGlobalId() const
         {
             return global_id_;
         }
@@ -581,23 +581,23 @@ namespace roadmanager
         {
         }
         ~LaneRoadMarkTypeLine(){};
-        double GetSOffset()
+        double GetSOffset() const
         {
             return s_offset_;
         }
-        double GetTOffset()
+        double GetTOffset() const
         {
             return t_offset_;
         }
-        double GetLength()
+        double GetLength() const
         {
             return length_;
         }
-        double GetSpace()
+        double GetSpace() const
         {
             return space_;
         }
-        double GetWidth()
+        double GetWidth() const
         {
             return width_;
         }
@@ -607,11 +607,11 @@ namespace roadmanager
         }
         OSIPoints osi_points_;
         void      SetGlobalId();
-        int       GetGlobalId()
+        int       GetGlobalId() const
         {
             return global_id_;
         }
-        RoadMarkColor GetColor()
+        RoadMarkColor GetColor() const
         {
             return color_;
         }
@@ -635,16 +635,16 @@ namespace roadmanager
         }
 
         void        AddLine(std::shared_ptr<LaneRoadMarkTypeLine> lane_roadMarkTypeLine);
-        std::string GetName()
+        std::string GetName() const
         {
             return name_;
         }
-        double GetWidth()
+        double GetWidth() const
         {
             return width_;
         }
-        LaneRoadMarkTypeLine *GetLaneRoadMarkTypeLineByIdx(int idx);
-        int                   GetNumberOfRoadMarkTypeLines()
+        LaneRoadMarkTypeLine *GetLaneRoadMarkTypeLineByIdx(int idx) const;
+        int                   GetNumberOfRoadMarkTypeLines() const
         {
             return (int)lane_roadMarkTypeLine_.size();
         }
@@ -712,44 +712,44 @@ namespace roadmanager
 
         void AddType(std::shared_ptr<LaneRoadMarkType> lane_roadMarkType);
 
-        double GetSOffset()
+        double GetSOffset() const
         {
             return s_offset_;
         }
-        double GetWidth()
+        double GetWidth() const
         {
             return width_;
         }
-        double GetHeight()
+        double GetHeight() const
         {
             return height_;
         }
-        RoadMarkType GetType()
+        RoadMarkType GetType() const
         {
             return type_;
         }
-        RoadMarkWeight GetWeight()
+        RoadMarkWeight GetWeight() const
         {
             return weight_;
         }
-        RoadMarkColor GetColor()
+        RoadMarkColor GetColor() const
         {
             return color_;
         }
-        RoadMarkMaterial GetMaterial()
+        RoadMarkMaterial GetMaterial() const
         {
             return material_;
         }
-        RoadMarkLaneChange GetLaneChange()
+        RoadMarkLaneChange GetLaneChange() const
         {
             return lane_change_;
         }
 
-        int GetNumberOfRoadMarkTypes()
+        int GetNumberOfRoadMarkTypes() const
         {
             return (int)lane_roadMarkType_.size();
         }
-        LaneRoadMarkType *GetLaneRoadMarkTypeByIdx(int idx);
+        LaneRoadMarkType *GetLaneRoadMarkTypeByIdx(int idx) const;
 
         static RoadMarkColor ParseColor(pugi::xml_node node);
         static std::string   RoadMarkColor2Str(RoadMarkColor color);
@@ -789,21 +789,21 @@ namespace roadmanager
         {
             length_ = length;
         }
-        double GetS()
+        double GetS() const
         {
             return s_;
         }
-        Polynomial GetPolynomial()
+        Polynomial GetPolynomial() const
         {
             return polynomial_;
         }
-        double GetLength()
+        double GetLength() const
         {
             return length_;
         }
-        double GetLaneOffset(double s);
-        double GetLaneOffsetPrim(double s);
-        void   Print();
+        double GetLaneOffset(double s) const;
+        double GetLaneOffsetPrim(double s) const;
+        void   Print() const;
 
     private:
         Polynomial polynomial_;
@@ -887,15 +887,15 @@ namespace roadmanager
         }
 
         // Base Get Functions
-        int GetId()
+        int GetId() const
         {
             return id_;
         }
-        LaneType GetLaneType()
+        LaneType GetLaneType() const
         {
             return type_;
         }
-        int GetGlobalId()
+        int GetGlobalId() const
         {
             return global_id_;
         }
@@ -909,35 +909,35 @@ namespace roadmanager
         void AddLaneRoadMark(LaneRoadMark *lane_roadMark);
 
         // Get Functions
-        int GetNumberOfRoadMarks()
+        int GetNumberOfRoadMarks() const
         {
             return (int)lane_roadMark_.size();
         }
-        int GetNumberOfLinks()
+        int GetNumberOfLinks() const
         {
             return (int)link_.size();
         }
-        int GetNumberOfLaneWidths()
+        int GetNumberOfLaneWidths() const
         {
             return (int)lane_width_.size();
         }
 
-        LaneLink     *GetLink(LinkType type);
-        LaneWidth    *GetWidthByIndex(int index);
-        LaneWidth    *GetWidthByS(double s);
-        LaneRoadMark *GetLaneRoadMarkByIdx(int idx);
+        LaneLink     *GetLink(LinkType type) const;
+        LaneWidth    *GetWidthByIndex(int index) const;
+        LaneWidth    *GetWidthByS(double s) const;
+        LaneRoadMark *GetLaneRoadMarkByIdx(int idx) const;
 
-        RoadMarkInfo GetRoadMarkInfoByS(int track_id, int lane_id, double s);
+        RoadMarkInfo GetRoadMarkInfoByS(int track_id, int lane_id, double s) const;
         OSIPoints   *GetOSIPoints()
         {
             return &osi_points_;
         }
-        std::vector<int> GetLineGlobalIds();
-        LaneBoundaryOSI *GetLaneBoundary()
+        std::vector<int> GetLineGlobalIds() const;
+        LaneBoundaryOSI *GetLaneBoundary() const
         {
             return lane_boundary_;
         }
-        int GetLaneBoundaryGlobalId();
+        int GetLaneBoundaryGlobalId() const;
 
         // Set Functions
         void SetGlobalId();
@@ -959,13 +959,13 @@ namespace roadmanager
         {
             return osiintersection_;
         }
-        void      Print();
+        void      Print() const;
         OSIPoints osi_points_;
         void      SetRoadEdge(bool value)
         {
             road_edge_ = value;
         }
-        bool IsRoadEdge()
+        bool IsRoadEdge() const
         {
             return road_edge_;
         }
@@ -998,19 +998,19 @@ namespace roadmanager
             lane_.clear();
         }
         void   AddLane(Lane *lane);
-        double GetS()
+        double GetS() const
         {
             return s_;
         }
-        Lane  *GetLaneByIdx(int idx);
-        Lane  *GetLaneById(int id);
-        int    GetLaneIdByIdx(int idx);
-        int    GetLaneIdxById(int id);
-        bool   IsOSILaneById(int id);
-        int    GetLaneGlobalIdByIdx(int idx);
-        int    GetLaneGlobalIdById(int id);
-        double GetOuterOffset(double s, int lane_id);
-        double GetWidth(double s, int lane_id);
+        Lane  *GetLaneByIdx(int idx) const;
+        Lane  *GetLaneById(int id) const;
+        int    GetLaneIdByIdx(int idx) const;
+        int    GetLaneIdxById(int id) const;
+        bool   IsOSILaneById(int id) const;
+        int    GetLaneGlobalIdByIdx(int idx) const;
+        int    GetLaneGlobalIdById(int id) const;
+        double GetOuterOffset(double s, int lane_id) const;
+        double GetWidth(double s, int lane_id) const;
 
         /**
         Get index of closest lane wrt given constraints
@@ -1022,7 +1022,7 @@ namespace roadmanager
                               int     side,
                               double &offset,
                               bool    noZeroWidth,
-                              int     laneTypeMask = Lane::LaneType::LANE_TYPE_ANY_DRIVING);
+                              int     laneTypeMask = Lane::LaneType::LANE_TYPE_ANY_DRIVING) const;
 
         /**
         Get lateral position of lane center, from road reference lane (lane id=0)
@@ -1032,29 +1032,29 @@ namespace roadmanager
         @param lane_id lane specifier, starting from center -1, -2, ... is on the right side, 1, 2... on the left
         @return Lateral position of lane center
         */
-        double GetCenterOffset(double s, int lane_id);
-        double GetOuterOffsetHeading(double s, int lane_id);
-        double GetCenterOffsetHeading(double s, int lane_id);
-        double GetLength()
+        double GetCenterOffset(double s, int lane_id) const;
+        double GetOuterOffsetHeading(double s, int lane_id) const;
+        double GetCenterOffsetHeading(double s, int lane_id) const;
+        double GetLength() const
         {
             return length_;
         }
-        int GetNumberOfLanes()
+        int GetNumberOfLanes() const
         {
             return (int)lane_.size();
         }
-        int  GetNumberOfDrivingLanes();
-        int  GetNumberOfDrivingLanesSide(int side);
-        int  GetNUmberOfLanesRight();
-        int  GetNUmberOfLanesLeft();
+        int  GetNumberOfDrivingLanes() const;
+        int  GetNumberOfDrivingLanesSide(int side) const;
+        int  GetNUmberOfLanesRight() const;
+        int  GetNUmberOfLanesLeft() const;
         void SetLength(double length)
         {
             length_ = length;
         }
-        int    GetConnectingLaneId(int incoming_lane_id, LinkType link_type);
-        double GetWidthBetweenLanes(int lane_id1, int lane_id2, double s);
-        double GetOffsetBetweenLanes(int lane_id1, int lane_id2, double s);
-        void   Print();
+        int    GetConnectingLaneId(int incoming_lane_id, LinkType link_type) const;
+        double GetWidthBetweenLanes(int lane_id1, int lane_id2, double s) const;
+        double GetOffsetBetweenLanes(int lane_id1, int lane_id2, double s) const;
+        void   Print() const;
 
     private:
         double              s_;
@@ -1093,24 +1093,24 @@ namespace roadmanager
         RoadLink(LinkType type, pugi::xml_node node);
         bool operator==(RoadLink &rhs);
 
-        int GetElementId()
+        int GetElementId() const
         {
             return element_id_;
         }
-        LinkType GetType()
+        LinkType GetType() const
         {
             return type_;
         }
-        RoadLink::ElementType GetElementType()
+        RoadLink::ElementType GetElementType() const
         {
             return element_type_;
         }
-        ContactPointType GetContactPointType()
+        ContactPointType GetContactPointType() const
         {
             return contact_point_type_;
         }
 
-        void Print();
+        void Print() const;
 
     private:
         LinkType         type_;
@@ -1148,19 +1148,19 @@ namespace roadmanager
         {
         }
 
-        double GetX()
+        double GetX() const
         {
             return x_;
         }  // X coordinate of sign position
-        double GetY()
+        double GetY() const
         {
             return y_;
         }  // Y coordinate of sign position
-        double GetZ()
+        double GetZ() const
         {
             return z_;
         }  // Z coordinate of road level at sign X, Y position
-        double GetH()
+        double GetH() const
         {
             return h_;
         }  // sign yaw rotation including "orientation" (+/-) but excluding h_offset
@@ -1446,19 +1446,19 @@ namespace roadmanager
                double      z,
                double      h);
 
-        std::string GetName()
+        std::string GetName() const
         {
             return name_;
         }
-        int GetId()
+        int GetId() const
         {
             return id_;
         }
-        double GetS()
+        double GetS() const
         {
             return s_;
         }
-        double GetT()
+        double GetT() const
         {
             return t_;
         }
@@ -1466,71 +1466,71 @@ namespace roadmanager
         {
             length_ = length;
         }
-        double GetLength()
+        double GetLength() const
         {
             return length_;
         }
-        double GetHOffset()
+        double GetHOffset() const
         {
             return h_offset_;
         }
-        double GetZOffset()
+        double GetZOffset() const
         {
             return z_offset_;
         }
-        Orientation GetOrientation()
+        Orientation GetOrientation() const
         {
             return orientation_;
         }
-        int GetOSIType()
+        int GetOSIType() const
         {
             return osi_type_;
         }
-        std::string GetType()
+        std::string GetType() const
         {
             return type_;
         }
-        std::string GetSubType()
+        std::string GetSubType() const
         {
             return subtype_;
         }
-        std::string GetCountry()
+        std::string GetCountry() const
         {
             return country_;
         }
-        double GetHeight()
+        double GetHeight() const
         {
             return height_;
         }
-        double GetWidth()
+        double GetWidth() const
         {
             return width_;
         }
-        bool IsDynamic()
+        bool IsDynamic() const
         {
             return dynamic_;
         }
-        double GetPitch()
+        double GetPitch() const
         {
             return pitch_;
         }
-        double GetRoll()
+        double GetRoll() const
         {
             return roll_;
         }
-        double GetValue()
+        double GetValue() const
         {
             return value_;
         }
-        std::string GetValueStr()
+        std::string GetValueStr() const
         {
             return value_str_;
         }
-        std::string GetUnit()
+        std::string GetUnit() const
         {
             return unit_;
         }
-        std::string GetText()
+        std::string GetText() const
         {
             return text_;
         }
@@ -1712,63 +1712,63 @@ namespace roadmanager
         {
             heightEnd_ = heightEnd;
         }
-        double GetS()
+        double GetS() const
         {
             return s_;
         }
-        double GetLength()
+        double GetLength() const
         {
             return length_;
         }
-        double GetDistance()
+        double GetDistance() const
         {
             return distance_;
         }
-        double GetTStart()
+        double GetTStart() const
         {
             return tStart_;
         }
-        double GetTEnd()
+        double GetTEnd() const
         {
             return tEnd_;
         }
-        double GetHeightStart()
+        double GetHeightStart() const
         {
             return heightStart_;
         }
-        double GetHeightEnd()
+        double GetHeightEnd() const
         {
             return heightEnd_;
         }
-        double GetZOffsetStart()
+        double GetZOffsetStart() const
         {
             return zOffsetStart_;
         }
-        double GetZOffsetEnd()
+        double GetZOffsetEnd() const
         {
             return zOffsetEnd_;
         }
-        double GetWidthStart()
+        double GetWidthStart() const
         {
             return widthStart_;
         }
-        double GetWidthEnd()
+        double GetWidthEnd() const
         {
             return widthEnd_;
         }
-        double GetLengthStart()
+        double GetLengthStart() const
         {
             return lengthStart_;
         }
-        double GetLengthEnd()
+        double GetLengthEnd() const
         {
             return lengthEnd_;
         }
-        double GetRadiusStart()
+        double GetRadiusStart() const
         {
             return radiusStart_;
         }
-        double GetRadiusEnd()
+        double GetRadiusEnd() const
         {
             return radiusEnd_;
         }
@@ -1856,55 +1856,55 @@ namespace roadmanager
         static std::string Type2Str(ObjectType type);
         static ObjectType  Str2Type(std::string type);
 
-        std::string GetName()
+        std::string GetName() const
         {
             return name_;
         }
-        std::string GetTypeStr()
+        std::string GetTypeStr() const
         {
             return Type2Str(type_);
         }
-        ObjectType GetType()
+        ObjectType GetType() const
         {
             return type_;
         }
-        int GetId()
+        int GetId() const
         {
             return id_;
         }
-        double GetS()
+        double GetS() const
         {
             return s_;
         }
-        double GetT()
+        double GetT() const
         {
             return t_;
         }
-        double GetHOffset()
+        double GetHOffset() const
         {
             return heading_;
         }
-        double GetPitch()
+        double GetPitch() const
         {
             return pitch_;
         }
-        double GetRoll()
+        double GetRoll() const
         {
             return roll_;
         }
-        double GetZOffset()
+        double GetZOffset() const
         {
             return z_offset_;
         }
-        double GetHeight()
+        double GetHeight() const
         {
             return height_;
         }
-        double GetLength()
+        double GetLength() const
         {
             return length_;
         }
-        double GetWidth()
+        double GetWidth() const
         {
             return width_;
         }
@@ -1920,7 +1920,7 @@ namespace roadmanager
         {
             width_ = width;
         }
-        Orientation GetOrientation()
+        Orientation GetOrientation() const
         {
             return orientation_;
         }
@@ -1933,25 +1933,25 @@ namespace roadmanager
         {
             repeats_.push_back(repeat);
         };
-        Repeat *GetRepeat()
+        Repeat *GetRepeat() const
         {
             return repeat_;
         }
 
-        int GetNumberOfOutlines()
+        int GetNumberOfOutlines() const
         {
             return (int)outlines_.size();
         }
-        int GetNumberOfRepeats()
+        int GetNumberOfRepeats() const
         {
             return (int)repeats_.size();
         }
 
-        Outline *GetOutline(int i)
+        Outline *GetOutline(int i) const
         {
             return (0 <= i && i < outlines_.size()) ? outlines_[i] : 0;
         }
-        Repeat *GetRepeatByIdx(int i)
+        Repeat *GetRepeatByIdx(int i) const
         {
             return (0 <= i && i < repeats_.size()) ? repeats_[i] : 0;
         }
@@ -2017,16 +2017,16 @@ namespace roadmanager
         }
         ~Road();
 
-        void Print();
+        void Print() const;
         void SetId(int id)
         {
             id_ = id;
         }
-        int GetId()
+        int GetId() const
         {
             return id_;
         }
-        RoadRule GetRule()
+        RoadRule GetRule() const
         {
             return rule_;
         }
@@ -2034,8 +2034,8 @@ namespace roadmanager
         {
             name_ = name;
         }
-        Geometry *GetGeometry(int idx);
-        int       GetNumberOfGeometries()
+        Geometry *GetGeometry(int idx) const;
+        int       GetNumberOfGeometries() const
         {
             return (int)geometry_.size();
         }
@@ -2049,19 +2049,19 @@ namespace roadmanager
         ...
         @param idx index into the vector of lane sections
         */
-        LaneSection *GetLaneSectionByIdx(int idx);
+        LaneSection *GetLaneSectionByIdx(int idx) const;
 
         /**
         Retrieve the lanesection index at specified s-value
         @param s distance along the road segment
         */
-        int GetLaneSectionIdxByS(double s, int start_at = 0);
+        int GetLaneSectionIdxByS(double s, int start_at = 0) const;
 
         /**
         Retrieve the lanesection at specified s-value
         @param s distance along the road segment
         */
-        LaneSection *GetLaneSectionByS(double s, int start_at = 0)
+        LaneSection *GetLaneSectionByS(double s, int start_at = 0) const
         {
             return GetLaneSectionByIdx(GetLaneSectionIdxByS(s, start_at));
         }
@@ -2073,24 +2073,24 @@ namespace roadmanager
         @param s distance along the road segment
         @param lane_id lane specifier, starting from center -1, -2, ... is on the right side, 1, 2... on the left
         */
-        double GetCenterOffset(double s, int lane_id);
+        double GetCenterOffset(double s, int lane_id) const;
 
         int            GetLaneInfoByS(double    s,
                                       int       start_lane_link_idx,
                                       int       start_lane_id,
                                       LaneInfo &lane_info,
-                                      int       laneTypeMask = Lane::LaneType::LANE_TYPE_ANY_DRIVING);
-        int            GetConnectingLaneId(RoadLink *road_link, int fromLaneId, int connectingRoadId);
-        double         GetLaneWidthByS(double s, int lane_id);
-        Lane::LaneType GetLaneTypeByS(double s, int lane_id);
-        double         GetSpeedByS(double s);
-        bool           GetZAndPitchByS(double s, double *z, double *z_prim, double *z_primPrim, double *pitch, int *index);
+                                      int       laneTypeMask = Lane::LaneType::LANE_TYPE_ANY_DRIVING) const;
+        int            GetConnectingLaneId(RoadLink *road_link, int fromLaneId, int connectingRoadId) const;
+        double         GetLaneWidthByS(double s, int lane_id) const;
+        Lane::LaneType GetLaneTypeByS(double s, int lane_id) const;
+        double         GetSpeedByS(double s) const;
+        bool           GetZAndPitchByS(double s, double *z, double *z_prim, double *z_primPrim, double *pitch, int *index) const;
         bool           UpdateZAndRollBySAndT(double s, double t, double *z, double *roadSuperElevationPrim, double *roll, int *index);
-        int            GetNumberOfLaneSections()
+        int            GetNumberOfLaneSections() const
         {
             return (int)lane_section_.size();
         }
-        std::string GetName()
+        std::string GetName() const
         {
             return name_;
         }
@@ -2122,8 +2122,8 @@ namespace roadmanager
         {
             return (int)type_.size();
         }
-        RoadTypeEntry *GetRoadType(int idx);
-        RoadLink      *GetLink(LinkType type);
+        RoadTypeEntry *GetRoadType(int idx) const;
+        RoadLink      *GetLink(LinkType type) const;
         void           AddLine(Line *line);
         void           AddArc(Arc *arc);
         void           AddSpiral(Spiral *spiral);
@@ -2135,31 +2135,31 @@ namespace roadmanager
         void           AddLaneOffset(LaneOffset *lane_offset);
         void           AddSignal(Signal *signal);
         void           AddObject(RMObject *object);
-        Elevation     *GetElevation(int idx);
-        Elevation     *GetSuperElevation(int idx);
-        int            GetNumberOfSignals();
-        Signal        *GetSignal(int idx);
-        int            GetNumberOfObjects()
+        Elevation     *GetElevation(int idx) const;
+        Elevation     *GetSuperElevation(int idx) const;
+        int            GetNumberOfSignals() const;
+        Signal        *GetSignal(int idx) const;
+        int            GetNumberOfObjects() const
         {
             return (int)object_.size();
         }
-        RMObject *GetRoadObject(int idx);
-        int       GetNumberOfElevations()
+        RMObject *GetRoadObject(int idx) const;
+        int       GetNumberOfElevations() const
         {
             return (int)elevation_profile_.size();
         }
-        int GetNumberOfSuperElevations()
+        int GetNumberOfSuperElevations() const
         {
             return (int)super_elevation_profile_.size();
         }
-        double GetLaneOffset(double s);
-        double GetLaneOffsetPrim(double s);
-        int    GetNumberOfLanes(double s);
-        int    GetNumberOfDrivingLanes(double s);
-        Lane  *GetDrivingLaneByIdx(double s, int idx);
-        Lane  *GetDrivingLaneSideByIdx(double s, int side, int idx);
-        Lane  *GetDrivingLaneById(double s, int idx);
-        int    GetNumberOfDrivingLanesSide(double s, int side);  // side = -1 right, 1 left
+        double GetLaneOffset(double s) const;
+        double GetLaneOffsetPrim(double s) const;
+        int    GetNumberOfLanes(double s) const;
+        int    GetNumberOfDrivingLanes(double s) const;
+        Lane  *GetDrivingLaneByIdx(double s, int idx) const;
+        Lane  *GetDrivingLaneSideByIdx(double s, int side, int idx) const;
+        Lane  *GetDrivingLaneById(double s, int idx) const;
+        int    GetNumberOfDrivingLanesSide(double s, int side) const;  // side = -1 right, 1 left
 
         /**
                 Given a lane id, get connected lane id at another longitudinal location at the same road
@@ -2169,7 +2169,7 @@ namespace roadmanager
                 @param s_target Stop at this s value
                 @return connected lane_id if found, else 0
         */
-        int GetConnectedLaneIdAtS(int lane_id, double s_start, double s_target);
+        int GetConnectedLaneIdAtS(int lane_id, double s_start, double s_target) const;
 
         /**
                 Check if specified road is directly connected to at specified end of current one (this)
@@ -2178,7 +2178,7 @@ namespace roadmanager
                 @param fromLaneId If not zero, a connection from this lane must exist on specified road
                 @return true if connection exist, else false
         */
-        bool IsDirectlyConnected(Road *road, LinkType link_type, ContactPointType *contact_point, int fromLaneId = 0);
+        bool IsDirectlyConnected(Road *road, LinkType link_type, ContactPointType *contact_point, int fromLaneId = 0) const;
 
         /**
                 Check if specified road is directly connected, at least in one end of current one (this)
@@ -2187,7 +2187,7 @@ namespace roadmanager
                 @param fromLaneId If not zero, a connection from this lane must exist on specified road
                 @return true if connection exist, else false
         */
-        bool IsDirectlyConnected(Road *road, double *curvature = 0, int fromLaneId = 0);
+        bool IsDirectlyConnected(Road *road, double *curvature = 0, int fromLaneId = 0) const;
 
         /**
                 Check if specified road is directly connected as successor to current one (this)
@@ -2196,7 +2196,7 @@ namespace roadmanager
                 @param fromLaneId If not zero, a connection from this lane must exist on specified road
                 @return true if connection exist, else false
         */
-        bool IsSuccessor(Road *road, ContactPointType *contact_point = 0, int fromLaneId = 0);
+        bool IsSuccessor(Road *road, ContactPointType *contact_point = 0, int fromLaneId = 0) const;
 
         /**
                 Check if specified road is directly connected as predecessor to current one (this)
@@ -2205,7 +2205,7 @@ namespace roadmanager
                 @param fromLaneId If not zero, a connection from this lane must exist on specified road
                 @return true if connection exist, else false
         */
-        bool IsPredecessor(Road *road, ContactPointType *contact_point = 0, int fromLaneId = 0);
+        bool IsPredecessor(Road *road, ContactPointType *contact_point = 0, int fromLaneId = 0) const;
 
         /**
                 Get width of road
@@ -2214,7 +2214,7 @@ namespace roadmanager
                 @param laneTypeMask Bitmask specifying what lane types to consider - see Lane::LaneType
                 @return Width (m)
         */
-        double GetWidth(double s, int side, int laneTypeMask = Lane::LaneType::LANE_TYPE_ANY);  // side: -1=right, 1=left, 0=both
+        double GetWidth(double s, int side, int laneTypeMask = Lane::LaneType::LANE_TYPE_ANY) const;  // side: -1=right, 1=left, 0=both
 
     protected:
         int         id_;
@@ -2263,15 +2263,15 @@ namespace roadmanager
         {
             connecting_lane_id_ = id;
         }
-        int GetLaneId()
+        int GetLaneId() const
         {
             return lane_id_;
         }
-        int GetConnectingRoadId()
+        int GetConnectingRoadId() const
         {
             return connecting_road_id_;
         }
-        int GetConnectinglaneId()
+        int GetConnectinglaneId() const
         {
             return connecting_lane_id_;
         }
@@ -2292,7 +2292,7 @@ namespace roadmanager
         }
         int  from_;
         int  to_;
-        void Print()
+        void Print() const
         {
             printf("JunctionLaneLink: from %d to %d\n", from_, to_);
         }
@@ -2303,29 +2303,29 @@ namespace roadmanager
     public:
         Connection(Road *incoming_road, Road *connecting_road, ContactPointType contact_point);
         ~Connection();
-        int GetNumberOfLaneLinks()
+        int GetNumberOfLaneLinks() const
         {
             return (int)lane_link_.size();
         }
-        JunctionLaneLink *GetLaneLink(int idx)
+        JunctionLaneLink *GetLaneLink(int idx) const
         {
             return lane_link_[idx];
         }
-        int   GetConnectingLaneId(int incoming_lane_id);
-        Road *GetIncomingRoad()
+        int   GetConnectingLaneId(int incoming_lane_id) const;
+        Road *GetIncomingRoad() const
         {
             return incoming_road_;
         }
-        Road *GetConnectingRoad()
+        Road *GetConnectingRoad() const
         {
             return connecting_road_;
         }
-        ContactPointType GetContactPoint()
+        ContactPointType GetContactPoint() const
         {
             return contact_point_;
         }
         void AddJunctionLaneLink(int from, int to);
-        void Print();
+        void Print() const;
 
     private:
         Road                           *incoming_road_;
@@ -2354,7 +2354,7 @@ namespace roadmanager
         {
             control_.push_back(ctrl);
         }
-        int GetNumberOfControls()
+        int GetNumberOfControls() const
         {
             return (int)control_.size();
         }
@@ -2363,15 +2363,15 @@ namespace roadmanager
             return ((index >= 0 && index < control_.size()) ? &control_[index] : nullptr);
         }
 
-        int GetId()
+        int GetId() const
         {
             return id_;
         }
-        std::string GetName()
+        std::string GetName() const
         {
             return name_;
         }
-        int GetSequence()
+        int GetSequence() const
         {
             return sequence_;
         }
@@ -2411,38 +2411,38 @@ namespace roadmanager
             SetGlobalId();
         }
         ~Junction();
-        int GetId()
+        int GetId() const
         {
             return id_;
         }
-        std::string GetName()
+        std::string GetName() const
         {
             return name_;
         }
-        int GetNumberOfConnections()
+        int GetNumberOfConnections() const
         {
             return (int)connection_.size();
         }
-        int                    GetNumberOfRoadConnections(int roadId, int laneId);
-        LaneRoadLaneConnection GetRoadConnectionByIdx(int roadId, int laneId, int idx, int laneTypeMask = Lane::LaneType::LANE_TYPE_ANY_DRIVING);
+        int                    GetNumberOfRoadConnections(int roadId, int laneId) const;
+        LaneRoadLaneConnection GetRoadConnectionByIdx(int roadId, int laneId, int idx, int laneTypeMask = Lane::LaneType::LANE_TYPE_ANY_DRIVING) const;
         void                   AddConnection(Connection *connection)
         {
             connection_.push_back(connection);
         }
-        int         GetNoConnectionsFromRoadId(int incomingRoadId);
-        Connection *GetConnectionByIdx(int idx)
+        int         GetNoConnectionsFromRoadId(int incomingRoadId) const;
+        Connection *GetConnectionByIdx(int idx) const
         {
             return connection_[idx];
         }
-        int  GetConnectingRoadIdFromIncomingRoadId(int incomingRoadId, int index);
-        void Print();
-        bool IsOsiIntersection();
-        int  GetGlobalId()
+        int  GetConnectingRoadIdFromIncomingRoadId(int incomingRoadId, int index) const;
+        void Print() const;
+        bool IsOsiIntersection() const;
+        int  GetGlobalId() const
         {
             return global_id_;
         }
         void SetGlobalId();
-        int  GetNumberOfControllers()
+        int  GetNumberOfControllers() const
         {
             return (int)controller_.size();
         }
@@ -2451,8 +2451,8 @@ namespace roadmanager
         {
             controller_.push_back(controller);
         }
-        Road        *GetRoadAtOtherEndOfConnectingRoad(Road *connecting_road, Road *incoming_road);
-        JunctionType GetType()
+        Road        *GetRoadAtOtherEndOfConnectingRoad(Road *connecting_road, Road *incoming_road) const;
+        JunctionType GetType() const
         {
             return type_;
         }
@@ -2517,7 +2517,7 @@ namespace roadmanager
         /**
                 Get the filename of currently loaded OpenDRIVE file
         */
-        std::string GetOpenDriveFilename()
+        std::string GetOpenDriveFilename() const
         {
             return odr_filename_;
         }
@@ -2526,7 +2526,7 @@ namespace roadmanager
                 Setting information based on the OSI standards for OpenDrive elements
         */
         bool SetRoadOSI();
-        bool CheckLaneOSIRequirement(std::vector<double> x0, std::vector<double> y0, std::vector<double> x1, std::vector<double> y1);
+        bool CheckLaneOSIRequirement(std::vector<double> x0, std::vector<double> y0, std::vector<double> x1, std::vector<double> y1) const;
         void SetLaneOSIPoints();
         void SetRoadMarkOSIPoints();
 
@@ -2540,7 +2540,7 @@ namespace roadmanager
                 Retrieve a road segment specified by road ID
                 @param id road ID as specified in the OpenDRIVE file
         */
-        Road *GetRoadById(int id);
+        Road *GetRoadById(int id) const;
 
         /**
                 Retrieve a road segment specified by road vector element index
@@ -2551,18 +2551,18 @@ namespace roadmanager
                 ...
                 @param idx index into the vector of roads
         */
-        Road     *GetRoadByIdx(int idx);
-        Geometry *GetGeometryByIdx(int road_idx, int geom_idx);
-        int       GetTrackIdxById(int id);
-        int       GetTrackIdByIdx(int idx);
-        int       GetNumOfRoads()
+        Road     *GetRoadByIdx(int idx) const;
+        Geometry *GetGeometryByIdx(int road_idx, int geom_idx) const;
+        int       GetTrackIdxById(int id) const;
+        int       GetTrackIdByIdx(int idx) const;
+        int       GetNumOfRoads() const
         {
             return (int)road_.size();
         }
-        Junction *GetJunctionById(int id);
-        Junction *GetJunctionByIdx(int idx);
+        Junction *GetJunctionById(int id) const;
+        Junction *GetJunctionByIdx(int idx) const;
 
-        int GetNumOfJunctions()
+        int GetNumOfJunctions() const
         {
             return (int)junction_.size();
         }
@@ -2572,7 +2572,7 @@ namespace roadmanager
                                    int *&connecting_road_id,
                                    int *&connecting_lane_id,
                                    int   lane1_id = 0,
-                                   int   lane2_id = 0);
+                                   int   lane2_id = 0) const;
 
         /**
                 Add any missing connections so that road connectivity is two-ways
@@ -2588,7 +2588,7 @@ namespace roadmanager
         static std::string ElementType2Str(RoadLink::ElementType type);
         static std::string LinkType2Str(LinkType link_type);
 
-        int GetNumberOfControllers()
+        int GetNumberOfControllers() const
         {
             return (int)controller_.size();
         }
@@ -2600,7 +2600,7 @@ namespace roadmanager
         }
 
         GeoReference *GetGeoReference();
-        std::string   GetGeoReferenceAsString();
+        std::string   GetGeoReferenceAsString() const;
         void          ParseGeoLocalization(const std::string &geoLocalization);
 
         bool LoadSignalsByCountry(const std::string &country);
@@ -2613,21 +2613,21 @@ namespace roadmanager
                 Get first specified speed unit (in road type elements). MS is default.
                 @return 0=Undefined, 1=km/h 2=m/s, 3=mph
         */
-        SpeedUnit GetSpeedUnit()
+        SpeedUnit GetSpeedUnit() const
         {
             return speed_unit_;
         }
 
-        int GetVersionMajor()
+        int GetVersionMajor() const
         {
             return versionMajor_;
         }
-        int GetVersionMinor()
+        int GetVersionMinor() const
         {
             return versionMinor_;
         }
 
-        void Print();
+        void Print() const;
 
     private:
         pugi::xml_node                     root_node_;
@@ -2864,7 +2864,7 @@ namespace roadmanager
             type_    = type;
         }
 
-        Position *GetRelativePosition()
+        Position *GetRelativePosition() const
         {
             return rel_pos_;
         }
@@ -2899,7 +2899,7 @@ namespace roadmanager
         Retrieve the S-value of the current route position. Note: This is the S along the
         complete route, not the actual individual roads.
         */
-        double GetRouteS();
+        double GetRouteS() const;
         /**
         Move current position forward, or backwards, ds meters along the route
         @param ds Distance to move, negative will move backwards
@@ -2941,7 +2941,7 @@ namespace roadmanager
         /**
         Retrieve the S-value of the current trajectory position
         */
-        double GetTrajectoryS()
+        double GetTrajectoryS() const
         {
             return s_trajectory_;
         }
@@ -2959,7 +2959,7 @@ namespace roadmanager
         /**
         Retrieve the T-value of the current trajectory position
         */
-        double GetTrajectoryT()
+        double GetTrajectoryT() const
         {
             return t_trajectory_;
         }
@@ -2990,7 +2990,7 @@ namespace roadmanager
         @param dist Distance (output parameter)
         @return 0 if position found and parameter values are valid, else -1
         */
-        int Distance(Position *pos_b, CoordinateSystem cs, RelativeDistanceType relDistType, double &dist, double maxDist = LARGE_NUMBER);
+        int Distance(Position *pos_b, CoordinateSystem cs, RelativeDistanceType relDistType, double &dist, double maxDist = LARGE_NUMBER) const;
 
         /**
         Find out the distance, on specified system and type, to a world x, y position
@@ -2999,7 +2999,7 @@ namespace roadmanager
         @param dist Distance (output parameter)
         @return 0 if position found and parameter values are valid, else -1
         */
-        int Distance(double x, double y, CoordinateSystem cs, RelativeDistanceType relDistType, double &dist, double maxDist = LARGE_NUMBER);
+        int Distance(double x, double y, CoordinateSystem cs, RelativeDistanceType relDistType, double &dist, double maxDist = LARGE_NUMBER) const;
 
         /**
         Is the current position ahead of the one specified in argument
@@ -3007,7 +3007,7 @@ namespace roadmanager
         @param target_position The position to compare the current to.
         @return true of false
         */
-        bool IsAheadOf(Position target_position);
+        bool IsAheadOf(Position target_position) const;
 
         /**
         Get information suitable for driver modeling of a point at a specified distance from object along the road ahead
@@ -3017,7 +3017,7 @@ namespace roadmanager
         enum
         @return 0 if successful, other codes see Position::ErrorCode
         */
-        ReturnCode GetProbeInfo(double lookahead_distance, RoadProbeInfo *data, LookAheadMode lookAheadMode);
+        ReturnCode GetProbeInfo(double lookahead_distance, RoadProbeInfo *data, LookAheadMode lookAheadMode) const;
 
         /**
         Get information suitable for driver modeling of a point at a specified distance from object along the road ahead
@@ -3025,7 +3025,7 @@ namespace roadmanager
         @param data Struct to fill in calculated values, see typdef for details
         @return 0 if successful, other codes see Position::ErrorCode
         */
-        ReturnCode GetProbeInfo(Position *target_pos, RoadProbeInfo *data);
+        ReturnCode GetProbeInfo(Position *target_pos, RoadProbeInfo *data) const;
 
         /**
         Get information of current lane at a specified distance from object along the road ahead
@@ -3035,8 +3035,8 @@ namespace roadmanager
         enum
         @return 0 if successful, -1 if not
         */
-        int GetRoadLaneInfo(double lookahead_distance, RoadLaneInfo *data, LookAheadMode lookAheadMode);
-        int GetRoadLaneInfo(RoadLaneInfo *data);
+        int GetRoadLaneInfo(double lookahead_distance, RoadLaneInfo *data, LookAheadMode lookAheadMode) const;
+        int GetRoadLaneInfo(RoadLaneInfo *data) const;
 
         /**
         Get information of current lane at a specified distance from object along the road ahead
@@ -3044,7 +3044,7 @@ namespace roadmanager
         @param data Struct to fill in calculated values, see typdef for details
         @return 0 if successful, -1 if not
         */
-        int CalcProbeTarget(Position *target, RoadProbeInfo *data);
+        int CalcProbeTarget(Position *target, RoadProbeInfo *data) const;
 
         double DistanceToDS(double ds);
 
@@ -3093,7 +3093,7 @@ namespace roadmanager
         Retrieve the global lane ID from the position object
         @return lane ID
         */
-        int GetLaneGlobalId();
+        int GetLaneGlobalId() const;
 
         /**
         Retrieve a road segment specified by road ID
@@ -3117,7 +3117,7 @@ namespace roadmanager
         /**
         Retrieve the offset from current lane
         */
-        double GetOffset();
+        double GetOffset() const;
 
         /**
         Retrieve the world coordinate X-value
@@ -3203,7 +3203,7 @@ namespace roadmanager
         /**
         Retrieve the world coordinate pitch angle (radians)
         */
-        double GetP();
+        double GetP() const;
 
         /**
         Retrieve the road pitch value
@@ -3216,12 +3216,12 @@ namespace roadmanager
         /**
         Retrieve the relative pitch angle (radians)
         */
-        double GetPRelative();
+        double GetPRelative() const;
 
         /**
         Retrieve the world coordinate roll angle (radians)
         */
-        double GetR();
+        double GetR() const;
 
         /**
         Retrieve the road roll value
@@ -3234,22 +3234,22 @@ namespace roadmanager
         /**
         Retrieve the relative roll angle (radians)
         */
-        double GetRRelative();
+        double GetRRelative() const;
 
         /**
         Retrieve the road pitch value, driving direction considered
         */
-        double GetPRoadInDrivingDirection();
+        double GetPRoadInDrivingDirection() const;
 
         /**
         Retrieve the road curvature at current position
         */
-        double GetCurvature();
+        double GetCurvature() const;
 
         /**
         Retrieve the speed limit at current position
         */
-        double GetSpeedLimit();
+        double GetSpeedLimit() const;
 
         /**
         Retrieve the road heading/direction at current position, and in the direction given by current lane
@@ -3317,15 +3317,15 @@ namespace roadmanager
         {
             h_acc_ = h_acc, p_acc_ = p_acc, r_acc_ = r_acc;
         }
-        double GetVelX()
+        double GetVelX() const
         {
             return velX_;
         }
-        double GetVelY()
+        double GetVelY() const
         {
             return velY_;
         }
-        double GetVelZ()
+        double GetVelZ() const
         {
             return velZ_;
         }
@@ -3333,12 +3333,12 @@ namespace roadmanager
         /**
         Get lateral component of velocity in vehicle local coordinate system
         */
-        double GetVelLat();
+        double GetVelLat() const;
 
         /**
         Get longitudinal component of velocity in vehicle local coordinate system
         */
-        double GetVelLong();
+        double GetVelLong() const;
 
         /**
         Get lateral and longitudinal component of velocity in vehicle local coordinate system
@@ -3347,17 +3347,17 @@ namespace roadmanager
         @param vlong reference parameter returning longitudinal velocity
         @return -
         */
-        void GetVelLatLong(double &vlat, double &vlong);
+        void GetVelLatLong(double &vlat, double &vlong) const;
 
         /**
         Get lateral component of acceleration in vehicle local coordinate system
         */
-        double GetAccLat();
+        double GetAccLat() const;
 
         /**
         Get longitudinal component of acceleration in vehicle local coordinate system
         */
-        double GetAccLong();
+        double GetAccLong() const;
 
         /**
         Get lateral and longitudinal component of acceleration in vehicle local coordinate system
@@ -3366,17 +3366,17 @@ namespace roadmanager
         @param along reference parameter returning longitudinal acceleration
         @return -
         */
-        void GetAccLatLong(double &alat, double &along);
+        void GetAccLatLong(double &alat, double &along) const;
 
         /**
         Get lateral component of velocity in road coordinate system
         */
-        double GetVelT();
+        double GetVelT() const;
 
         /**
         Get longitudinal component of velocity in road coordinate system
         */
-        double GetVelS();
+        double GetVelS() const;
 
         /**
         Get lateral and longitudinal component of velocity in road coordinate system
@@ -3385,22 +3385,22 @@ namespace roadmanager
         @param vs reference parameter returning longitudinal velocity
         @return -
         */
-        void GetVelTS(double &vt, double &vs);
+        void GetVelTS(double &vt, double &vs) const;
 
         /**
         Get lateral component of acceleration in road coordinate system
         */
-        double GetAccT();
+        double GetAccT() const;
 
         /**
         Get longitudinal component of acceleration in road coordinate system
         */
-        double GetAccS();
+        double GetAccS() const;
 
         /**
         Get magnitude of acceleration. Sign indicating direction, accelerating (+) or decelerating (-)
         */
-        double GetAcc();
+        double GetAcc() const;
 
         /**
         Get lateral and longitudinal component of acceleration in road coordinate system
@@ -3409,46 +3409,46 @@ namespace roadmanager
         @param as reference parameter returning longitudinal acceleration
         @return -
         */
-        void GetAccTS(double &at, double &as);
+        void GetAccTS(double &at, double &as) const;
 
-        double GetAccX()
+        double GetAccX() const
         {
             return accX_;
         }
-        double GetAccY()
+        double GetAccY() const
         {
             return accY_;
         }
-        double GetAccZ()
+        double GetAccZ() const
         {
             return accZ_;
         }
-        double GetHRate()
+        double GetHRate() const
         {
             return h_rate_;
         }
-        double GetPRate()
+        double GetPRate() const
         {
             return p_rate_;
         }
-        double GetRRate()
+        double GetRRate() const
         {
             return r_rate_;
         }
-        double GetHAcc()
+        double GetHAcc() const
         {
             return h_acc_;
         }
-        double GetPAcc()
+        double GetPAcc() const
         {
             return p_acc_;
         }
-        double GetRAcc()
+        double GetRAcc() const
         {
             return r_acc_;
         }
 
-        int GetStatusBitMask()
+        int GetStatusBitMask() const
         {
             return status_;
         }
@@ -3457,7 +3457,7 @@ namespace roadmanager
         {
             orientation_type_ = type;
         }
-        OrientationType GetOrientationType()
+        OrientationType GetOrientationType() const
         {
             return orientation_type_;
         }
@@ -3482,19 +3482,19 @@ namespace roadmanager
             align_h_ = align_p_ = align_r_ = align_z_ = mode;
         }
 
-        ALIGN_MODE GetAlignModeH()
+        ALIGN_MODE GetAlignModeH() const
         {
             return align_h_;
         }
-        ALIGN_MODE GetAlignModeP()
+        ALIGN_MODE GetAlignModeP() const
         {
             return align_p_;
         }
-        ALIGN_MODE GetAlignModeR()
+        ALIGN_MODE GetAlignModeR() const
         {
             return align_r_;
         }
-        ALIGN_MODE GetAlignModeZ()
+        ALIGN_MODE GetAlignModeZ() const
         {
             return align_z_;
         }
@@ -3509,22 +3509,22 @@ namespace roadmanager
             snapToLaneTypes_ = laneTypeMask;
         }
 
-        int GetSnapLaneTypes()
+        int GetSnapLaneTypes() const
         {
             return snapToLaneTypes_;
         }
 
         void CopyRMPos(Position *from);
 
-        void PrintTrackPos();
-        void PrintLanePos();
-        void PrintInertialPos();
+        void PrintTrackPos() const;
+        void PrintLanePos() const;
+        void PrintInertialPos() const;
 
-        void Print();
-        void PrintXY();
+        void Print() const;
+        void PrintXY() const;
 
-        bool IsOffRoad();
-        bool IsInJunction();
+        bool IsOffRoad() const;
+        bool IsInJunction() const;
 
         /**
         Get the number of roads overlapping the position
@@ -3537,7 +3537,7 @@ namespace roadmanager
         @parameter index Index of the total returned by GetNumberOfRoadsOverlapping()
         @return Id of specified overlapping road
         */
-        int GetOverlappingRoadId(int index);
+        int GetOverlappingRoadId(int index) const;
 
         void ReplaceObjectRefs(Position *pos1, Position *pos2)
         {
@@ -3556,11 +3556,11 @@ namespace roadmanager
             lockOnLane_ = mode;
         }
 
-        int GetOrientationSetMask()
+        int GetOrientationSetMask() const
         {
             return orientationSetMask;
         }
-        bool IsOrientationTypeSet(OrientationSetMask bit)
+        bool IsOrientationTypeSet(OrientationSetMask bit) const
         {
             return static_cast<int>(bit) & orientationSetMask;
         }
@@ -3578,12 +3578,12 @@ namespace roadmanager
             zSet = value;
         }
 
-        bool GetZSet()
+        bool GetZSet() const
         {
             return zSet;
         }
 
-        RouteStrategy GetRouteStrategy()
+        RouteStrategy GetRouteStrategy() const
         {
             return routeStrategy_;
         }
@@ -3705,37 +3705,37 @@ namespace roadmanager
         int GetWayPointDirection(int index);
 
         void        setName(std::string name);
-        std::string getName();
-        double      GetLength()
+        std::string getName() const;
+        double      GetLength() const
         {
             return length_;
         }
         void CheckValid();
-        bool IsValid()
+        bool IsValid() const
         {
             return !invalid_route_;
         }
 
         // Current route position data
         // Actual object position might differ, e.g. laneId or even trackId in junctions
-        double GetTrackS()
+        double GetTrackS() const
         {
             return currentPos_.GetS();
         }
-        double GetPathS()
+        double GetPathS() const
         {
             return path_s_;
         }
-        int GetLaneId()
+        int GetLaneId() const
         {
             return currentPos_.GetLaneId();
         }
-        int GetTrackId()
+        int GetTrackId() const
         {
             return currentPos_.GetTrackId();
         }
         Position *GetWaypoint(int index = -1);  // -1 means current
-        Road     *GetRoadAtOtherEndOfConnectingRoad(Road *incoming_road);
+        Road     *GetRoadAtOtherEndOfConnectingRoad(Road *incoming_road) const;
         Position *GetCurrentPosition()
         {
             return &currentPos_;
@@ -3897,7 +3897,7 @@ namespace roadmanager
          */
         int FindPointAtTimeRelative(double time, TrajVertex &pos, int &index, int startAtIndex = 0);
 
-        int GetNumberOfVertices()
+        int GetNumberOfVertices() const
         {
             return (int)vertex_.size();
         }

--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.hpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.hpp
@@ -2424,7 +2424,10 @@ namespace roadmanager
             return (int)connection_.size();
         }
         int                    GetNumberOfRoadConnections(int roadId, int laneId) const;
-        LaneRoadLaneConnection GetRoadConnectionByIdx(int roadId, int laneId, int idx, int laneTypeMask = Lane::LaneType::LANE_TYPE_ANY_DRIVING) const;
+        LaneRoadLaneConnection GetRoadConnectionByIdx(int roadId,
+                                                      int laneId,
+                                                      int idx,
+                                                      int laneTypeMask = Lane::LaneType::LANE_TYPE_ANY_DRIVING) const;
         void                   AddConnection(Connection *connection)
         {
             connection_.push_back(connection);
@@ -2567,12 +2570,8 @@ namespace roadmanager
             return (int)junction_.size();
         }
 
-        bool IsIndirectlyConnected(int   road1_id,
-                                   int   road2_id,
-                                   int *&connecting_road_id,
-                                   int *&connecting_lane_id,
-                                   int   lane1_id = 0,
-                                   int   lane2_id = 0) const;
+        bool IsIndirectlyConnected(int road1_id, int road2_id, int *&connecting_road_id, int *&connecting_lane_id, int lane1_id = 0, int lane2_id = 0)
+            const;
 
         /**
                 Add any missing connections so that road connectivity is two-ways


### PR DESCRIPTION
Hey Emil,

A while ago I mentioned that I like (and use) [const correctness](https://isocpp.org/wiki/faq/const-correctness) a lot, which over time lead me to add it here and there around RoadManager when I needed it. But since I don't do that very often and nearly always forget to cherry-pick and make a PR out of it, well...

So I figured I might as well go over all of RoadManager and do it once and for all. Some notes:
* I only did it for method signatures, *not* for method parameters
* I skipped over some classes I didn't know of (I'm out of date on the standard it seems 😅 ), like `Shape` and `OutlineCorner`
* Interestingly, some methods that looked like they could be `const`'d actually couldn't, like `Position::GetNumberOfRoadsOverlapping()` ([link](https://github.com/esmini/esmini/blob/41f5f0834b719b7444c4cf1263c6a9d2f2c01044/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp#L9057))

Thanks again for all your work. RoadManager is at the core of what we do in Unreal, and I can't imagine what we'd do without it. The library has also proven very robust, even with the more and more complex road networks we build, so it's a real testament to the quality of your work.