### PR TITLE
Fix versioning in modelDescription

### DIFF
--- a/OSMP_FMU/CMakeLists.txt
+++ b/OSMP_FMU/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.5)
 set(TARGET EsminiOsiSource)
 project(${TARGET})
 
+set(VERSION "2.0.0")
+
 set(STATIC_LINKING TRUE)
 
 if(LINUX)
@@ -79,6 +81,9 @@ set(VERBOSE_FMI_LOGGING
 set(DEBUG_BREAKS
     OFF
     CACHE BOOL "Enable debugger traps for debug builds of FMU")
+
+set(OSIVERSION "3.5.0")
+set(OSMPVERSION "1.4.0")
 
 string(TIMESTAMP FMUTIMESTAMP UTC)
 string(MD5 FMUGUID modelDescription.in.xml)

--- a/OSMP_FMU/CMakeLists.txt
+++ b/OSMP_FMU/CMakeLists.txt
@@ -3,7 +3,9 @@ cmake_minimum_required(VERSION 3.5)
 set(TARGET EsminiOsiSource)
 project(${TARGET})
 
-set(VERSION "2.0.0")
+set(VERSION "2.32.1")
+set(OSIVERSION "3.5.0")
+set(OSMPVERSION "1.4.0")
 
 set(STATIC_LINKING TRUE)
 
@@ -81,9 +83,6 @@ set(VERBOSE_FMI_LOGGING
 set(DEBUG_BREAKS
     OFF
     CACHE BOOL "Enable debugger traps for debug builds of FMU")
-
-set(OSIVERSION "3.5.0")
-set(OSMPVERSION "1.4.0")
 
 string(TIMESTAMP FMUTIMESTAMP UTC)
 string(MD5 FMUGUID modelDescription.in.xml)

--- a/OSMP_FMU/modelDescription.in.xml
+++ b/OSMP_FMU/modelDescription.in.xml
@@ -5,7 +5,7 @@
   guid="@FMUGUID@"
   description="esmini scnario player packaged as OSMP FMU outputting an osi3::SensorView with GoundTruth from the scenario"
   author="Persival GmbH"
-  version="@OSMPVERSION@"
+  version="@VERSION@"
   generationTool="manual"
   generationDateAndTime="@FMUTIMESTAMP@"
   variableNamingConvention="structured">


### PR DESCRIPTION
In an OSMP modelDescription, there are 3 different version to set. None of them are set in the current master branch, as pointed out by https://github.com/esmini/esmini/issues/475.

In this PR 3 versions are set in the CMakeLists of the OSMP FMU:
- VERSION: Version of the FMU itself. We could set it to the same version number as esmini itself. @eknabe can we access this directly in the repository? the version.txt does not contain the actual version number.
- OSIVERSION: OSI version used by esmini. As already mentioned in the corresponding issue: @eknabe any idea on how to set this automatically?
- OSMPVERSION: Can be set manually, depending on which OSMP version is actually used, as implemented in this PR, 