### PR TITLE
Add osi3::TrafficCommand as additional output for esmini OSMP FMU

### DIFF
--- a/OSMP_FMU/EsminiOsiSource.h
+++ b/OSMP_FMU/EsminiOsiSource.h
@@ -55,7 +55,13 @@ using namespace std;
 #define FMI_INTEGER_SENSORVIEW_OUT_BASELO_IDX 3
 #define FMI_INTEGER_SENSORVIEW_OUT_BASEHI_IDX 4
 #define FMI_INTEGER_SENSORVIEW_OUT_SIZE_IDX 5
-#define FMI_INTEGER_LAST_IDX FMI_INTEGER_SENSORVIEW_OUT_SIZE_IDX
+#define FMI_INTEGER_TRAFFICCOMMANDUPDATE_IN_BASELO_IDX 6
+#define FMI_INTEGER_TRAFFICCOMMANDUPDATE_IN_BASEHI_IDX 7
+#define FMI_INTEGER_TRAFFICCOMMANDUPDATE_IN_SIZE_IDX 8
+#define FMI_INTEGER_TRAFFICCOMMAND_OUT_BASELO_IDX 9
+#define FMI_INTEGER_TRAFFICCOMMAND_OUT_BASEHI_IDX 10
+#define FMI_INTEGER_TRAFFICCOMMAND_OUT_SIZE_IDX 11
+#define FMI_INTEGER_LAST_IDX FMI_INTEGER_TRAFFICCOMMAND_OUT_SIZE_IDX
 #define FMI_INTEGER_VARS (FMI_INTEGER_LAST_IDX+1)
 
 /* Real Variables */
@@ -76,6 +82,7 @@ using namespace std;
 #undef min
 #undef max
 #include "osi_sensorview.pb.h"
+#include "osi_trafficcommand.pb.h"
 
 /* FMU Class */
 class EsminiOsiSource {
@@ -210,4 +217,7 @@ protected:
     bool get_fmi_traffic_update_in(osi3::TrafficUpdate& data);
     void set_fmi_sensor_view_out(const osi3::SensorView& data);
     void reset_fmi_sensor_view_out();
+    //bool get_fmi_traffic_command_update_in(osi3::TrafficCommandUpdate& data);     //TODO: Wait for OSI update
+    void set_fmi_traffic_command_out(const osi3::TrafficCommand& data);
+    void reset_fmi_traffic_command_out();
 };

--- a/OSMP_FMU/modelDescription.in.xml
+++ b/OSMP_FMU/modelDescription.in.xml
@@ -3,7 +3,7 @@
   fmiVersion="2.0"
   modelName="esmini"
   guid="@FMUGUID@"
-  description="esmini scnario player packaged as OSMP FMU outputting an osi3::SensorView with GoundTruth from the scenario"
+  description="esmini scnario player packaged as OSMP FMU outputting an osi3::SensorView with GoundTruth from the scenario and osi3::TrafficCommand with actions from OpenScenario"
   author="Persival GmbH"
   version="@VERSION@"
   generationTool="manual"
@@ -63,6 +63,42 @@
         <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewOut" role="size" mime-type="application/x-open-simulation-interface; type=SensorView; version=@OSIVERSION@"/></Tool>
       </Annotations>
     </ScalarVariable>
+    <ScalarVariable name="OSMPTrafficCommandUpdateIn.base.lo" valueReference="6" causality="input" variability="discrete">
+      <Integer start="0"/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPTrafficCommandUpdateIn" role="base.lo" mime-type="application/x-open-simulation-interface; type=TrafficUpdate; version=@OSIVERSION@"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPTrafficCommandUpdateIn.base.hi" valueReference="7" causality="input" variability="discrete">
+      <Integer start="0"/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPTrafficCommandUpdateIn" role="base.hi" mime-type="application/x-open-simulation-interface; type=TrafficUpdate; version=@OSIVERSION@"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPTrafficCommandUpdateIn.size" valueReference="8" causality="input" variability="discrete">
+      <Integer start="0"/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPTrafficCommandUpdateIn" role="size" mime-type="application/x-open-simulation-interface; type=TrafficUpdate; version=@OSIVERSION@"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPTrafficCommandOut.base.lo" valueReference="9" causality="output" variability="discrete" initial="exact">
+      <Integer start="0"/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPTrafficCommandOut" role="base.lo" mime-type="application/x-open-simulation-interface; type=SensorView; version=@OSIVERSION@"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPTrafficCommandOut.base.hi" valueReference="10" causality="output" variability="discrete" initial="exact">
+      <Integer start="0"/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPTrafficCommandOut" role="base.hi" mime-type="application/x-open-simulation-interface; type=SensorView; version=@OSIVERSION@"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPTrafficCommandOut.size" valueReference="11" causality="output" variability="discrete" initial="exact">
+      <Integer start="0"/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPTrafficCommandOut" role="size" mime-type="application/x-open-simulation-interface; type=SensorView; version=@OSIVERSION@"/></Tool>
+      </Annotations>
+    </ScalarVariable>
     <ScalarVariable name="valid" valueReference="0" causality="output" variability="discrete" initial="exact">
       <Boolean start="false"/>
     </ScalarVariable>
@@ -78,7 +114,10 @@
       <Unknown index="4"/>
       <Unknown index="5"/>
       <Unknown index="6"/>
-      <Unknown index="7"/>
+      <Unknown index="10"/>
+      <Unknown index="11"/>
+      <Unknown index="12"/>
+      <Unknown index="13"/>
     </Outputs>
   </ModelStructure>
 </fmiModelDescription>


### PR DESCRIPTION
OSMP Traffic Participant models are able to optionally receive osi3::TrafficCommand data next to the standard osi3::SensorView, according to the [OSMP model type specification](https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/sensor-model/spec/model_types.html).

The TrafficCommand message contains actions, that align with the OpenSCENARIO definitions, e.g. speed actions or lane change actions. The idea is, that a scenario player reads these actions from an OpenSCENARIO file and passes them along to a traffic participant model.

In this PR, the following features are added to facilitate this functionality:

- [x] Add osi3::TrafficCommand as additional output
- [ ] Set traffic actions from OpenSCENARIO (as read by esmini) in the TrafficCommand output
- [ ] Add osi3::TrafficCommandUpdate as additional input
- [ ] Output a log message based on the received TrafficCommandUpdate

Fixes #499 