### PR TITLE
Fix CommonMini version generation

### DIFF
--- a/EnvironmentSimulator/Modules/CommonMini/version.cmake
+++ b/EnvironmentSimulator/Modules/CommonMini/version.cmake
@@ -33,6 +33,9 @@ else()
                 "${GIT_REV}")
 
     string(
+        STRIP "${GIT_REV}"
+              GIT_REV)
+    string(
         STRIP "${GIT_TAG}"
               GIT_TAG)
     string(


### PR DESCRIPTION
Build fails sometimes because GIT_REV contains trailing spaces