### PR TITLE
Apply VisibilityAction to connected tow and trailer vehicles

### DIFF
--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
@@ -2371,6 +2371,18 @@ void VisibilityAction::Start(double simTime)
     OSCAction::Start(simTime);
     object_->SetVisibilityMask((graphics_ ? Object::Visibility::GRAPHICS : 0) | (traffic_ ? Object::Visibility::TRAFFIC : 0) |
                                (sensors_ ? Object::Visibility::SENSORS : 0));
+    auto towVehicle = object_->TowVehicle();
+    if (towVehicle)
+    {
+        towVehicle->SetVisibilityMask((graphics_ ? Object::Visibility::GRAPHICS : 0) | (traffic_ ? Object::Visibility::TRAFFIC : 0) |
+                                      (sensors_ ? Object::Visibility::SENSORS : 0));
+    }
+    auto TrailerVehicle = object_->TrailerVehicle();
+    if (TrailerVehicle)
+    {
+        TrailerVehicle->SetVisibilityMask((graphics_ ? Object::Visibility::GRAPHICS : 0) | (traffic_ ? Object::Visibility::TRAFFIC : 0) |
+                                          (sensors_ ? Object::Visibility::SENSORS : 0));
+    }
 }
 
 void VisibilityAction::Step(double simTime, double dt)


### PR DESCRIPTION
Now passing the VisibilityAction to connected tow and trailer vehicles.

Before, when using e.g. a semi_truck and applying a `VisibilityAction` in the form of
```
<PrivateAction>
    <VisibilityAction sensors="false" graphics="false" traffic="false" />
</PrivateAction>
```
only the truck itself was affected by the `VisibilityAction`. The connected trailer, which is a different object, stayed visible.