### PR TITLE
Updated swarm traffic to change heading based on RHT or LHT

### DIFF
--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCGlobalAction.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCGlobalAction.cpp
@@ -565,7 +565,22 @@ void SwarmTrafficAction::spawn(Solutions sols, int replace, double simTime)
 
             Vehicle* vehicle = new Vehicle(*vehicle_pool_[static_cast<unsigned int>(number)]);
             vehicle->pos_.SetLanePos(inf.pos.GetTrackId(), laneID, inf.pos.GetS(), 0.0);
-            vehicle->pos_.SetHeadingRelativeRoadDirection(laneID < 0 ? 0.0 : M_PI);
+
+            // Set swarm traffic direction based on RHT or LHT
+            if (inf.road->GetRule() == roadmanager::Road::RoadRule::RIGHT_HAND_TRAFFIC)
+            {
+                vehicle->pos_.SetHeadingRelativeRoadDirection(laneID < 0 ? 0.0 : M_PI);
+            }
+            else if (inf.road->GetRule() == roadmanager::Road::RoadRule::LEFT_HAND_TRAFFIC)
+            {
+                vehicle->pos_.SetHeadingRelativeRoadDirection(laneID > 0 ? 0.0 : M_PI);
+            }
+            else
+            {
+                // do something if undefined... maybe default to RHT?
+                vehicle->pos_.SetHeadingRelativeRoadDirection(laneID < 0 ? 0.0 : M_PI);
+            }
+
             vehicle->SetSpeed(velocity_);
             // vehicle->scaleMode_ = EntityScaleMode::BB_TO_MODEL;
             vehicle->name_ = "swarm_" + std::to_string(counter_++);


### PR DESCRIPTION
We had an issue where the swarm traffic action was only working for RHT. I have added a check to find the traffic direction from ODR and swapped the heading around for LHT. 

After visualising this for scenarios with LHT and RHT it then worked. I'm not sure if there is anything else that would need changing for completeness apart from the SetHeadingRelativeRoadDirection?

I have also left it to default to RHT when the traffic direction is undefined, you may want to change this. 