### PR TITLE
Add arguments to ignore z, pitch and roll inputs from OSC

### DIFF
--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -537,7 +537,7 @@ extern "C"
         return InitScenario();
     }
 
-    static int AddCommonArguments(int disable_ctrls, int use_viewer, int threads, int record)
+    static int AddCommonArguments(int disable_ctrls, int use_viewer, int threads, int record, bool ignore_z, bool ignore_p, bool ignore_r)
     {
         (void)record;
         if ((use_viewer & 1) == 0)
@@ -581,10 +581,32 @@ extern "C"
             AddArgument("--disable_controllers");
         }
 
+        if (ignore_z)
+        {
+            AddArgument("--ignore_z");
+        }
+
+        if (ignore_p)
+        {
+            AddArgument("--ignore_p");
+        }
+
+        if (ignore_r)
+        {
+            AddArgument("--ignore_r");
+        }
+
         return 0;
     }
 
-    SE_DLL_API int SE_InitWithString(const char *oscAsXMLString, int disable_ctrls, int use_viewer, int threads, int record)
+    SE_DLL_API int SE_InitWithString(const char *oscAsXMLString,
+                                     int         disable_ctrls,
+                                     int         use_viewer,
+                                     int         threads,
+                                     int         record,
+                                     bool        ignore_z,
+                                     bool        ignore_p,
+                                     bool        ignore_r)
     {
 #ifndef _USE_OSG
         if (use_viewer)
@@ -604,7 +626,7 @@ extern "C"
             AddArgument(SE_Env::Inst().GetDatFilePath().c_str(), false);
         }
 
-        AddCommonArguments(disable_ctrls, use_viewer, threads, record);
+        AddCommonArguments(disable_ctrls, use_viewer, threads, record, ignore_z, ignore_p, ignore_r);
 
         return InitScenario();
     }
@@ -614,7 +636,8 @@ extern "C"
         RegisterParameterDeclarationCallback(fnPtr, user_data);
     }
 
-    SE_DLL_API int SE_Init(const char *oscFilename, int disable_ctrls, int use_viewer, int threads, int record)
+    SE_DLL_API int
+    SE_Init(const char *oscFilename, int disable_ctrls, int use_viewer, int threads, int record, bool ignore_z, bool ignore_p, bool ignore_r)
     {
 #ifndef _USE_OSG
         if (use_viewer)
@@ -643,7 +666,7 @@ extern "C"
             AddArgument(datFilename.c_str(), false);
         }
 
-        AddCommonArguments(disable_ctrls, use_viewer, threads, record);
+        AddCommonArguments(disable_ctrls, use_viewer, threads, record, ignore_z, ignore_p, ignore_r);
 
         return InitScenario();
     }

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -428,6 +428,9 @@ extern "C"
        1+2=3=>Off-screen
             @param threads 0=single thread, 1=viewer in a separate thread, parallel to scenario engine
             @param record Create recording for later playback 0=no recording 1=recording
+            @param ignore_z 0=use z values from OSC file, 1=ignore z values from OSC file and place vehicle relative to road (z=0)
+            @param ignore_p 0=use pitch values from OSC file, 1=ignore pitch values from OSC file and rotate vehicle relative to road (p=0)
+            @param ignore_r 0=use roll values from OSC file, 1=ignore roll values from OSC file and rotate vehicle relative to road (r=0)
             @return 0 if successful, -1 if not
 
             \use_viewer bitmask examples:
@@ -437,7 +440,14 @@ extern "C"
                             7 (1+2+4): Off-screen + save screenshots to file
                        11 (1+2+8): Off-screen + disable info-text for better remote/virtual desktop support
     */
-    SE_DLL_API int SE_Init(const char *oscFilename, int disable_ctrls, int use_viewer, int threads, int record);
+    SE_DLL_API int SE_Init(const char *oscFilename,
+                           int         disable_ctrls,
+                           int         use_viewer,
+                           int         threads,
+                           int         record,
+                           bool        ignore_z = false,
+                           bool        ignore_p = false,
+                           bool        ignore_r = false);
 
     /**
             Initialize the scenario engine
@@ -448,6 +458,9 @@ extern "C"
        1+2=3=>Off-screen
             @param threads 0=single thread, 1=viewer in a separate thread, parallel to scenario engine
             @param record Create recording for later playback 0=no recording 1=recording
+            @param ignore_z 0=use z values from OSC file, 1=ignore z values from OSC file and place vehicle relative to road (z=0)
+            @param ignore_p 0=use pitch values from OSC file, 1=ignore pitch values from OSC file and rotate vehicle relative to road (p=0)
+            @param ignore_r 0=use roll values from OSC file, 1=ignore roll values from OSC file and rotate vehicle relative to road (r=0)
             @return 0 if successful, -1 if not
 
             \use_viewer bitmask examples:
@@ -457,7 +470,14 @@ extern "C"
                             7 (1+2+4): Off-screen + save screenshots to file
                        11 (1+2+8): Off-screen + disable info-text for better remote/virtual desktop support
     */
-    SE_DLL_API int SE_InitWithString(const char *oscAsXMLString, int disable_ctrls, int use_viewer, int threads, int record);
+    SE_DLL_API int SE_InitWithString(const char *oscAsXMLString,
+                                     int         disable_ctrls,
+                                     int         use_viewer,
+                                     int         threads,
+                                     int         record,
+                                     bool        ignore_z = false,
+                                     bool        ignore_p = false,
+                                     bool        ignore_r = false);
 
     /**
             Initialize the scenario engine

--- a/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp
+++ b/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp
@@ -65,6 +65,9 @@ ScenarioPlayer::ScenarioPlayer(int argc, char* argv[])
     CSV_Log              = NULL;
     osiReporter          = NULL;
     disable_controllers_ = false;
+    ignore_z_            = false;
+    ignore_p_            = false;
+    ignore_r_            = false;
     frame_counter_       = 0;
     scenarioEngine       = nullptr;
     osiReporter          = nullptr;
@@ -1304,6 +1307,9 @@ int ScenarioPlayer::Init()
     opt.AddOption("help", "Show this help message");
     opt.AddOption("hide_route_waypoints", "Disable route waypoint visualization (toggle with key 'R')");
     opt.AddOption("hide_trajectories", "Hide trajectories from start (toggle with key 'n')");
+    opt.AddOption("ignore_z", "Ignore provided z values from OSC file and place vehicle relative to road");
+    opt.AddOption("ignore_p", "Ignore provided pitch values from OSC file and place vehicle relative to road");
+    opt.AddOption("ignore_r", "Ignore provided roll values from OSC file and place vehicle relative to road");
     opt.AddOption("info_text", "Show on-screen info text (toggle key 'i') mode 0=None 1=current (default) 2=per_object 3=both", "mode");
     opt.AddOption("logfile_path", "logfile path/filename, e.g. \"../esmini.log\" (default: log.txt)", "path");
     opt.AddOption("osc_str", "OpenSCENARIO XML string", "string");
@@ -1530,6 +1536,24 @@ int ScenarioPlayer::Init()
         LOG("Disable entity controllers");
     }
 
+    if (opt.GetOptionSet("ignore_z"))
+    {
+        ignore_z_ = true;
+        LOG("Ignoring z values and placing vehicle relative to road");
+    }
+
+    if (opt.GetOptionSet("ignore_p"))
+    {
+        ignore_p_ = true;
+        LOG("Ignoring pitch values and placing vehicle relative to road");
+    }
+
+    if (opt.GetOptionSet("ignore_r"))
+    {
+        ignore_r_ = true;
+        LOG("Ignoring roll values and placing vehicle relative to road");
+    }
+
     // Use specific seed for repeatable scenarios?
     if ((arg_str = opt.GetOptionArg("seed")) != "")
     {
@@ -1572,7 +1596,7 @@ int ScenarioPlayer::Init()
         if ((arg_str = opt.GetOptionArg("osc")) != "")
         {
             SE_Env::Inst().AddPath(DirNameOf(arg_str));  // add scenario directory to list pf paths
-            scenarioEngine = new ScenarioEngine(arg_str, disable_controllers_);
+            scenarioEngine = new ScenarioEngine(arg_str, disable_controllers_, ignore_z_, ignore_p_, ignore_r_);
             Logger::Inst().SetTimePtr(scenarioEngine->GetSimulationTimePtr());
         }
         else if ((arg_str = opt.GetOptionArg("osc_str")) != "")
@@ -1584,7 +1608,7 @@ int ScenarioPlayer::Init()
             {
                 return -1;
             }
-            scenarioEngine = new ScenarioEngine(doc, disable_controllers_);
+            scenarioEngine = new ScenarioEngine(doc, disable_controllers_, ignore_z_, ignore_p_, ignore_r_);
             Logger::Inst().SetTimePtr(scenarioEngine->GetSimulationTimePtr());
         }
         else

--- a/EnvironmentSimulator/Modules/PlayerBase/playerbase.hpp
+++ b/EnvironmentSimulator/Modules/PlayerBase/playerbase.hpp
@@ -253,6 +253,9 @@ namespace scenarioengine
         bool        threads;
         bool        launch_server;
         bool        disable_controllers_;
+        bool        ignore_z_;
+        bool        ignore_p_;
+        bool        ignore_r_;
         double      fixed_timestep_;
         int         osi_freq_;
         int         frame_counter_;

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
@@ -34,33 +34,36 @@ namespace scenarioengine
     }
 }  // namespace scenarioengine
 
-ScenarioEngine::ScenarioEngine(std::string oscFilename, bool disable_controllers)
+ScenarioEngine::ScenarioEngine(std::string oscFilename, bool disable_controllers, bool ignore_z, bool ignore_p, bool ignore_r)
 {
-    init_status_ = InitScenario(oscFilename, disable_controllers);
+    init_status_ = InitScenario(oscFilename, disable_controllers, ignore_z, ignore_p, ignore_r);
 }
 
-ScenarioEngine::ScenarioEngine(const pugi::xml_document& xml_doc, bool disable_controllers)
+ScenarioEngine::ScenarioEngine(const pugi::xml_document& xml_doc, bool disable_controllers, bool ignore_z, bool ignore_p, bool ignore_r)
 {
-    init_status_ = InitScenario(xml_doc, disable_controllers);
+    init_status_ = InitScenario(xml_doc, disable_controllers, ignore_z, ignore_p, ignore_r);
 }
 
-void ScenarioEngine::InitScenarioCommon(bool disable_controllers)
+void ScenarioEngine::InitScenarioCommon(bool disable_controllers, bool ignore_z, bool ignore_p, bool ignore_r)
 {
     init_status_         = 0;
     disable_controllers_ = disable_controllers;
+    ignore_z_            = ignore_z;
+    ignore_p_            = ignore_p;
+    ignore_r_            = ignore_r;
     simulationTime_      = 0;
     trueTime_            = 0;
     frame_nr_            = 0;
-    scenarioReader       = new ScenarioReader(&entities_, &catalogs, disable_controllers);
+    scenarioReader       = new ScenarioReader(&entities_, &catalogs, disable_controllers, ignore_z, ignore_p, ignore_r);
     injected_actions_    = nullptr;
     ghost_               = nullptr;
     SE_Env::Inst().SetGhostMode(GhostMode::NORMAL);
     SE_Env::Inst().SetGhostHeadstart(0.0);
 }
 
-int ScenarioEngine::InitScenario(std::string oscFilename, bool disable_controllers)
+int ScenarioEngine::InitScenario(std::string oscFilename, bool disable_controllers, bool ignore_z, bool ignore_p, bool ignore_r)
 {
-    InitScenarioCommon(disable_controllers);
+    InitScenarioCommon(disable_controllers, ignore_z, ignore_p, ignore_r);
 
     std::string oscFilename_no_path = FileNameOf(oscFilename);
 
@@ -106,9 +109,9 @@ int ScenarioEngine::InitScenario(std::string oscFilename, bool disable_controlle
     return parseScenario();
 }
 
-int ScenarioEngine::InitScenario(const pugi::xml_document& xml_doc, bool disable_controllers)
+int ScenarioEngine::InitScenario(const pugi::xml_document& xml_doc, bool disable_controllers, bool ignore_z, bool ignore_p, bool ignore_r)
 {
-    InitScenarioCommon(disable_controllers);
+    InitScenarioCommon(disable_controllers, ignore_z, ignore_p, ignore_r);
 
     if (scenarioReader->loadOSCMem(xml_doc) != 0)
     {

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.hpp
@@ -49,13 +49,29 @@ namespace scenarioengine
         std::vector<CollisionPair> collision_pair_;
         std::vector<OSCAction *>  *injected_actions_;
 
-        ScenarioEngine(std::string oscFilename, bool disable_controllers = false);
-        ScenarioEngine(const pugi::xml_document &xml_doc, bool disable_controllers = false);
+        ScenarioEngine(std::string oscFilename,
+                       bool        disable_controllers = false,
+                       bool        ignore_z            = false,
+                       bool        ignore_p            = false,
+                       bool        ignore_r            = false);
+        ScenarioEngine(const pugi::xml_document &xml_doc,
+                       bool                      disable_controllers = false,
+                       bool                      ignore_z            = false,
+                       bool                      ignore_p            = false,
+                       bool                      ignore_r            = false);
         ~ScenarioEngine();
 
-        void InitScenarioCommon(bool disable_controllers);
-        int  InitScenario(std::string oscFilename, bool disable_controllers = false);
-        int  InitScenario(const pugi::xml_document &xml_doc, bool disable_controllers = false);
+        void InitScenarioCommon(bool disable_controllers, bool ignore_z, bool ignore_p, bool ignore_r);
+        int  InitScenario(std::string oscFilename,
+                          bool        disable_controllers = false,
+                          bool        ignore_z            = false,
+                          bool        ignore_p            = false,
+                          bool        ignore_r            = false);
+        int  InitScenario(const pugi::xml_document &xml_doc,
+                          bool                      disable_controllers = false,
+                          bool                      ignore_z            = false,
+                          bool                      ignore_p            = false,
+                          bool                      ignore_r            = false);
         void SetInjectedActionsPtr(std::vector<OSCAction *> *injected_actions)
         {
             injected_actions_ = injected_actions;
@@ -158,6 +174,9 @@ namespace scenarioengine
         RoadNetwork             roadNetwork;
         roadmanager::OpenDrive *odrManager;
         bool                    disable_controllers_;
+        bool                    ignore_z_;
+        bool                    ignore_p_;
+        bool                    ignore_r_;
 
         // Simulation parameters
         double          simulationTime_;

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioReader.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioReader.cpp
@@ -54,10 +54,13 @@ typedef struct
 
 static std::vector<StoryBoardElementTriggerInfo> storyboard_element_triggers;
 
-ScenarioReader::ScenarioReader(Entities *entities, Catalogs *catalogs, bool disable_controllers)
+ScenarioReader::ScenarioReader(Entities *entities, Catalogs *catalogs, bool disable_controllers, bool ignore_z, bool ignore_p, bool ignore_r)
     : entities_(entities),
       catalogs_(catalogs),
       disable_controllers_(disable_controllers),
+      ignore_z_(ignore_z),
+      ignore_p_(ignore_p),
+      ignore_r_(ignore_r),
       story_board_(nullptr)
 {
     parameters.Clear();
@@ -1654,7 +1657,7 @@ OSCPosition *ScenarioReader::parseOSCPosition(pugi::xml_node positionNode, OSCPo
         {
             y = strtod(parameters.ReadAttribute(positionChild, "y", true));
         }
-        if (!positionChild.attribute("z").empty())
+        if (!ignore_z_ && !positionChild.attribute("z").empty())
         {
             z = strtod(parameters.ReadAttribute(positionChild, "z", true));
         }
@@ -1662,11 +1665,11 @@ OSCPosition *ScenarioReader::parseOSCPosition(pugi::xml_node positionNode, OSCPo
         {
             h = strtod(parameters.ReadAttribute(positionChild, "h", true));
         }
-        if (!positionChild.attribute("p").empty())
+        if (!ignore_p_ && !positionChild.attribute("p").empty())
         {
             p = strtod(parameters.ReadAttribute(positionChild, "p", true));
         }
-        if (!positionChild.attribute("r").empty())
+        if (!ignore_r_ && !positionChild.attribute("r").empty())
         {
             r = strtod(parameters.ReadAttribute(positionChild, "r", true));
         }

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioReader.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioReader.hpp
@@ -70,7 +70,12 @@ namespace scenarioengine
     class ScenarioReader
     {
     public:
-        ScenarioReader(Entities* entities, Catalogs* catalogs, bool disable_controllers = false);
+        ScenarioReader(Entities* entities,
+                       Catalogs* catalogs,
+                       bool      disable_controllers = false,
+                       bool      ignore_z            = false,
+                       bool      ignore_p            = false,
+                       bool      ignore_r            = false);
         ~ScenarioReader();
         int  loadOSCFile(const char* path);
         int  loadOSCMem(const pugi::xml_document& xml_doch);
@@ -191,6 +196,9 @@ namespace scenarioengine
         ScenarioGateway*      gateway_;
         ScenarioEngine*       scenarioEngine_;
         bool                  disable_controllers_;
+        bool                  ignore_z_;
+        bool                  ignore_p_;
+        bool                  ignore_r_;
         static ControllerPool controllerPool_;
         int                   versionMajor_;
         int                   versionMinor_;


### PR DESCRIPTION
We have the use case where an input OpenScenario contains z, pitch and roll values which do not perfectly fit to the underlying OpenDrive, i.e., the vehicle is flying or its orientation does not match the road.

Instead of working on the OpenScenario, I added arguments `ignore_z`, `ignore_p`, `ignore_r` to ignore these values and make use of esmini's relative positioning on the road.

Usage is not affected if the arguments are not provided.

Running a scenario which has "wrong" z inputs:
```
esmini --osc input_z+5.xosc --window 600 600 600 400
```
![image](https://github.com/esmini/esmini/assets/28296759/f5142cf4-b22c-4ea3-82aa-320e2d3cbb74)

Running it and ignoring the "wrong" z inputs:
```
esmini --osc input_z+5.xosc --window 600 600 600 400 --ignore_z
```
![image](https://github.com/esmini/esmini/assets/28296759/4fff708c-f885-416b-b368-3cc94f280249)

**However, I still notice a bug where the connected tow and trailer vehicles already had this feature, i.e. they are currently always placed relative to the road and ignore the z from the towing vehicle**