### PR TITLE
Add new option 'disable_ghost_triggering'

### DIFF
--- a/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp
+++ b/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp
@@ -1302,6 +1302,7 @@ int ScenarioPlayer::Init()
                   "Additional custom light source <x,y,z,intensity> intensity range 0..1 (multiple occurrences supported)",
                   "position and intensity");
     opt.AddOption("disable_controllers", "Disable controllers");
+    opt.AddOption("disable_ghost_triggering", "Do not use ghost vehicle to trigger actions");
     opt.AddOption("disable_pline_interpolation", "Do not apply orientation interpolation of polyline trajectories");
     opt.AddOption("disable_log", "Prevent logfile from being created");
     opt.AddOption("disable_stdout", "Prevent messages to stdout");
@@ -1542,6 +1543,11 @@ int ScenarioPlayer::Init()
     {
         disable_controllers_ = true;
         LOG("Disable entity controllers");
+    }
+
+    if (opt.GetOptionSet("disable_ghost_triggering"))
+    {
+        LOG("Not using ghost vehicle to trigger actions");
     }
 
     if (opt.GetOptionSet("ignore_z"))


### PR DESCRIPTION
Added a new option `disable_ghost_triggering`, which can be set to avoid moving all actions to the ghost vehicle (if it is used of course).
This can be helpful in some cases. Example use case would be the following `ExampleAction` with a `StartTrigger`, which has a `ReachPositionCondition`:
```
<ManeuverGroup maximumExecutionCount="1" name="ExampleManeuverGroup">
    <Actors selectTriggeringEntities="false">
        <EntityRef entityRef="Ego"/>
    </Actors>
    <Maneuver name="ExampleManeuver">
        <Event priority="overwrite" name="ExampleEvent">
            <Action name="ExampleAction">
                <PrivateAction>
                    <LongitudinalAction>
                        <SpeedAction>
                            <SpeedActionDynamics dynamicsDimension="rate" value="1.0" dynamicsShape="linear"/>
                            <SpeedActionTarget>
                                <AbsoluteTargetSpeed value="10.0"/>
                            </SpeedActionTarget>
                        </SpeedAction>
                    </LongitudinalAction>
                </PrivateAction>
            </Action>
            <StartTrigger>
                <ConditionGroup>
                    <Condition conditionEdge="rising" delay="0.0" name="ExampleCondition">
                        <ByEntityCondition>
                            <TriggeringEntities triggeringEntitiesRule="all">
                                <EntityRef entityRef="Ego"/>
                            </TriggeringEntities>
                            <EntityCondition>
                                <ReachPositionCondition tolerance="0.5">
                                    <Position>
                                        <WorldPosition x="5.0" y="5.0" z="0.0"/>
                                    </Position>
                                </ReachPositionCondition>
                            </EntityCondition>
                        </ByEntityCondition>
                    </Condition>
                </ConditionGroup>
            </StartTrigger>
        </Event>
    </Maneuver>
</ManeuverGroup>
```
Here, the `ExampleCondition` is currently triggered as soon as the ghost vehicle reaches the stated position `(5.0, 5.0, 0.0)`. However, due to, e.g., custom controller settings or the ghost headstart time, the ego vehicle can still be far away from that position, and I want to trigger that condition only if the ego vehicle reaches the stated position.

The option can be set from command line, e.g. by running
```
esmini --window 500 500 1000 800 --osc test.xosc --disable_ghost_triggering
```
or by setting it via API (prior to a call to `SE_Init()`):
```
SE_SetOption("disable_ghost_triggering");
```