### PR TITLE
Add option to disable external downloads and build odrplot and examples optionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ set(ENABLE_INCLUDE_WHAT_YOU_USE
     CACHE BOOL
           "Enable iwyu")
 
+set(DOWNLOAD_EXTERNALS
+    ON
+    CACHE BOOL
+          "Download external packages")
+
 set(USE_OSG
     ON
     CACHE BOOL
@@ -157,6 +162,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/support/cmake/cloud/download.cmake)
 
 message(STATUS "Downloading dependencies...")
 
+if(DOWNLOAD_EXTERNALS)
 download(
     osg
     ${EXTERNALS_OSG_PATH}
@@ -202,7 +208,7 @@ if(NOT
         "*"
         "${GTEST_PACKAGE_URL}")
 endif()
-
+endif()
 # ############################### Loading external packages ##########################################################
 
 if(USE_GTEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,10 +91,20 @@ set(USE_IMPLOT
     CACHE BOOL
           "If implot for real-time plotting should be compiled.")
 
+set(BUILD_ODRPLOT
+    ON
+    CACHE BOOL
+          "If odrplot should be compiled.")
+
 set(BUILD_REPLAYER
     ON
     CACHE BOOL
           "If replayer should be compiled.")
+
+set(BUILD_EXAMPLES
+    ON
+    CACHE BOOL
+          "If examples should be compiled.")
 
 set(ESMINI_BUILD_VERSION
     "N/A - client build"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,58 +165,58 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/support/cmake/utils/set_folder.cmake)
 
 # ############################### Downloading cloud packages #########################################################
 if(DOWNLOAD_EXTERNALS)
-include(${CMAKE_CURRENT_SOURCE_DIR}/support/cmake/cloud/set_cloud_links.cmake)
-set_cloud_links()
+    include(${CMAKE_CURRENT_SOURCE_DIR}/support/cmake/cloud/set_cloud_links.cmake)
+    set_cloud_links()
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/support/cmake/cloud/download.cmake)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/support/cmake/cloud/download.cmake)
 
-message(STATUS "Downloading dependencies...")
+    message(STATUS "Downloading dependencies...")
 
-download(
-    osg
-    ${EXTERNALS_OSG_PATH}
-    ${EXTERNALS_OSG_OS_SPECIFIC_PATH}
-    "*"
-    "${OSG_PACKAGE_URL}")
-
-download(
-    osi
-    ${EXTERNALS_OSI_PATH}
-    ${EXTERNALS_OSI_OS_SPECIFIC_PATH}
-    "*"
-    "${OSI_PACKAGE_URL}")
-
-download(
-    sumo
-    ${EXTERNALS_SUMO_PATH}
-    ${EXTERNALS_SUMO_OS_SPECIFIC_PATH}
-    "*"
-    "${SUMO_PACKAGE_URL}")
-
-download(
-    implot
-    ${EXTERNALS_IMPLOT_PATH}
-    ${EXTERNALS_IMPLOT_OS_SPECIFIC_PATH}
-    "*"
-    "${IMPLOT_PACKAGE_URL}")
-
-download(
-    models
-    ${RESOURCES_PATH}
-    ${MODELS_PATH}
-    "models"
-    "${MODELS_PACKAGE_URL}")
-
-if(NOT
-   (APPLE
-    OR MINGW))
     download(
-        googletest
-        ${EXTERNALS_GOOGLETEST_PATH}
-        ${EXTERNALS_GOOGLETEST_OS_SPECIFIC_PATH}
+        osg
+        ${EXTERNALS_OSG_PATH}
+        ${EXTERNALS_OSG_OS_SPECIFIC_PATH}
         "*"
-        "${GTEST_PACKAGE_URL}")
-endif()
+        "${OSG_PACKAGE_URL}")
+
+    download(
+        osi
+        ${EXTERNALS_OSI_PATH}
+        ${EXTERNALS_OSI_OS_SPECIFIC_PATH}
+        "*"
+        "${OSI_PACKAGE_URL}")
+
+    download(
+        sumo
+        ${EXTERNALS_SUMO_PATH}
+        ${EXTERNALS_SUMO_OS_SPECIFIC_PATH}
+        "*"
+        "${SUMO_PACKAGE_URL}")
+
+    download(
+        implot
+        ${EXTERNALS_IMPLOT_PATH}
+        ${EXTERNALS_IMPLOT_OS_SPECIFIC_PATH}
+        "*"
+        "${IMPLOT_PACKAGE_URL}")
+
+    download(
+        models
+        ${RESOURCES_PATH}
+        ${MODELS_PATH}
+        "models"
+        "${MODELS_PACKAGE_URL}")
+
+    if(NOT
+       (APPLE
+        OR MINGW))
+        download(
+            googletest
+            ${EXTERNALS_GOOGLETEST_PATH}
+            ${EXTERNALS_GOOGLETEST_OS_SPECIFIC_PATH}
+            "*"
+            "${GTEST_PACKAGE_URL}")
+    endif()
 endif()
 # ############################### Loading external packages ##########################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/support/cmake/utils/get_subdirectories.cmake
 include(${CMAKE_CURRENT_SOURCE_DIR}/support/cmake/utils/set_folder.cmake)
 
 # ############################### Downloading cloud packages #########################################################
-
+if(DOWNLOAD_EXTERNALS)
 include(${CMAKE_CURRENT_SOURCE_DIR}/support/cmake/cloud/set_cloud_links.cmake)
 set_cloud_links()
 
@@ -162,7 +162,6 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/support/cmake/cloud/download.cmake)
 
 message(STATUS "Downloading dependencies...")
 
-if(DOWNLOAD_EXTERNALS)
 download(
     osg
     ${EXTERNALS_OSG_PATH}

--- a/EnvironmentSimulator/CMakeLists.txt
+++ b/EnvironmentSimulator/CMakeLists.txt
@@ -31,12 +31,15 @@ add_subdirectory(Applications/esmini-dyn)
 if(USE_OSG)
     add_subdirectory(Applications/odrviewer)
 endif(USE_OSG)
+if(BUILD_ODRPLOT)
 add_subdirectory(Applications/odrplot)
+endif(BUILD_ODRPLOT)
 if(BUILD_REPLAYER)
     add_subdirectory(Applications/replayer)
 endif(BUILD_REPLAYER)
-add_subdirectory(code-examples)
-
+if(BUILD_EXAMPLES)
+    add_subdirectory(code-examples)
+endif(BUILD_EXAMPLES)
 # ############################### Building Unittest ####################################################################
 
 if((NOT
@@ -93,9 +96,11 @@ set_folder(
 set_folder(
     dat2csv
     ${ApplicationsFolder})
+if(BUILD_ODRPLOT)
 set_folder(
     odrplot
     ${ApplicationsFolder})
+endif(BUILD_ODRPLOT)
 if(BUILD_REPLAYER)
     set_folder(
         replayer

--- a/EnvironmentSimulator/CMakeLists.txt
+++ b/EnvironmentSimulator/CMakeLists.txt
@@ -32,7 +32,7 @@ if(USE_OSG)
     add_subdirectory(Applications/odrviewer)
 endif(USE_OSG)
 if(BUILD_ODRPLOT)
-add_subdirectory(Applications/odrplot)
+    add_subdirectory(Applications/odrplot)
 endif(BUILD_ODRPLOT)
 if(BUILD_REPLAYER)
     add_subdirectory(Applications/replayer)
@@ -97,9 +97,9 @@ set_folder(
     dat2csv
     ${ApplicationsFolder})
 if(BUILD_ODRPLOT)
-set_folder(
-    odrplot
-    ${ApplicationsFolder})
+    set_folder(
+        odrplot
+        ${ApplicationsFolder})
 endif(BUILD_ODRPLOT)
 if(BUILD_REPLAYER)
     set_folder(


### PR DESCRIPTION
This PR introduces an option to disable external package downloads and makes building odrplot and examples optional. The default build behavior remains unchanged while adding CMake variables for more granular build control.