### PR TITLE
Add pre-commit checks and workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,10 +6,10 @@ on:
       - master
       - dev
       - 'feature/**'
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
   pull_request:
-      
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,15 +3,14 @@ repos:
     rev: v19.1.7
     hooks:
       - id: clang-format
-        types: [file]
-        files: ".*\\.(cpp|hpp)"
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13
     hooks:
       - id: cmake-format
+        additional_dependencies: [pyyaml>=5.1]
       - id: cmake-lint
-        files: ".*\\.(cmake|CMakeLists.txt)"
+        additional_dependencies: [pyyaml>=5.1]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
This PR introduces `pre-commit` hooks to enforce code quality and consistency before committing changes. It also adds a corresponding CI workflow to check and fix each incoming PR automatically.

Currently, the `esmini` repo does not pass these checks. This can be tested locally by:

```
pre-commit run --all-files
```

after installing `pre-commit` Python library. 

Ref: https://pre-commit.com/
