### PR TITLE
Fix event transition to "Complete" creation and trigger in esmini for events containing ParameterSetAction

### DIFF
--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioReader.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioReader.cpp
@@ -2161,10 +2161,10 @@ OSCGlobalAction *ScenarioReader::parseOSCGlobalAction(pugi::xml_node actionNode,
             {
                 if (paramChild.name() == std::string("SetAction"))
                 {
-                    ParameterSetAction *paramSetAction = new ParameterSetAction(action);
+                    ParameterSetAction *paramSetAction = new ParameterSetAction(parent);
 
-                    // give user a message about depricated action.. use variable instead...
-                    LOG_WARN("Parameter SetAction depricated from OSC 1.2. Please use Variable SetAction instead. Accepting for this time.");
+                    // give user a message about deprecated action.. use variable instead...
+                    LOG_WARN("Parameter SetAction deprecated from OSC 1.2. Please use Variable SetAction instead. Accepting for this time.");
 
                     paramSetAction->name_       = parameters.ReadAttribute(actionChild, "parameterRef");
                     paramSetAction->value_      = parameters.ReadAttribute(paramChild, "value");


### PR DESCRIPTION
Closes https://github.com/esmini/esmini/issues/677

**Context**:
<details open>
When defining an Event that contains a single Action which is only responsible for setting a parameter like shown in the snippet below:

```xml
<Event maximumExecutionCount="1" name="Event 1" priority="parallel">
  <Action name="Action 1">
  	<GlobalAction>
  		<ParameterAction parameterRef="my_parameter">
  			<SetAction value="7" />
  		</ParameterAction>
  	</GlobalAction>
  </Action>
  <StartTrigger>
      <ConditionGroup>
          <Condition delay="0" conditionEdge="none" name="simulation_time">
              <ByValueCondition>
                  <SimulationTimeCondition value="0.0" rule="greaterThan"/>
              </ByValueCondition>
          </Condition>
      </ConditionGroup>
  </StartTrigger>
</Event>
```

The following logs show up on running a scenario with the above pattern:
```
[0.000] [info] Event 1 Condition 1-1: true, delay: 0.00, 0.0000 >= 0.0000, edge: none
[0.000] [info] Trigger /------------------------------------------------
[0.000] [info] Group 0:
[0.000] [info] Event 1 Condition 1-1: true
[0.000] [info] Trigger  ------------------------------------------------/
[0.000] [info] Event 1 standbyState -> startTransition -> runningState
[0.000] [info] Set parameter my_parameter = 1
[0.000] [info] Event 1 Action 1 initState -> startTransition -> runningState
[0.000] [info] Event 1 Action 1 runningState -> stopTransition -> completeState
```

Interestingly we don't see the logs at 0 seconds which blocks any Events defined subsequently:
```
[0.000] [info] Event 1 complete after 1 execution
[0.000] [info] Event 1 runningState -> endTransition -> completeState
```

Furthermore this same pattern used to work in older versions of esmini, i.e. esmini-2.36.2 and below.
</details>

**Root Cause**: It seems like this [commit](https://github.com/esmini/esmini/commit/dc669c8153e3fdbb9d90b811e3a018336d1c0608) caused this regression.

Specifically in ScenarioReader.cpp the following change was made:
```
-                     ParameterSetAction *paramSetAction = new ParameterSetAction();
+                    ParameterSetAction *paramSetAction = new ParameterSetAction(action);
```

In contrast `VariableSetAction`, which works on the current version of esmini uses `parent` too instead of `action` and seems to work as expected. This also seems consistent since the empty constructor for ParameterSetAction in the previously working version of esmini [here](https://github.com/esmini/esmini/commit/dc669c8153e3fdbb9d90b811e3a018336d1c0608#diff-cdad7de0aab4f0fc52beb55758d8aebfb810c584e6e76b4d60ed7da215fd71a3) is now equivalent to the constructor that takes in a `parent` and not an `action`.

Let me know if you'd like me to add any tests for the same. 