### PR TITLE
Fix SetupGhost to handle Acts with Start Triggers and delays to only replace triggers to ghost if necessary

### DIFF
--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
@@ -1101,7 +1101,7 @@ void ScenarioEngine::SetupGhost(Object* object)
         for (size_t j = 0; j < story->act_.size(); j++)
         {
             Act* act = story->act_[j];
-            ReplaceObjectInTrigger(act->start_trigger_, object, ghost, -ghost->GetHeadstartTime());
+            bool ghostIsActorInAct = false;
             for (size_t k = 0; k < act->maneuverGroup_.size(); k++)
             {
                 ManeuverGroup* mg = act->maneuverGroup_[k];
@@ -1119,7 +1119,7 @@ void ScenarioEngine::SetupGhost(Object* object)
                     for (size_t m = 0; m < maneuver->event_.size(); m++)
                     {
                         Event* event        = maneuver->event_[m];
-                        bool   ghostIsActor = false;
+                        bool   ghostIsActorInEvent = false;
                         for (size_t n = 0; n < event->action_.size(); n++)
                         {
                             OSCAction* action = event->action_[n];
@@ -1131,7 +1131,9 @@ void ScenarioEngine::SetupGhost(Object* object)
                                 {
                                     // If at least one of the event actions is of relevant subset of action types
                                     // then move the action to the ghost object instance, and also make needed
-                                    // changes to the event trigger
+                                    // changes to the event trigger (such as offsetting the start time).
+                                    // Similarly, we also make sure that the Act containing a ghost object also
+                                    // transfers its triggers to the ghost object.
                                     if (pa->action_type_ == OSCPrivateAction::ActionType::LONG_SPEED ||
                                         pa->action_type_ == OSCPrivateAction::ActionType::LONG_SPEED_PROFILE ||
                                         pa->action_type_ == OSCPrivateAction::ActionType::LAT_LANE_CHANGE ||
@@ -1143,18 +1145,23 @@ void ScenarioEngine::SetupGhost(Object* object)
                                     {
                                         // Replace object
                                         pa->ReplaceObjectRefs(object, ghost);
-                                        ghostIsActor = true;
+                                        ghostIsActorInEvent = true;
+                                        ghostIsActorInAct = true;
                                     }
                                 }
                             }
                         }
-                        if (ghostIsActor)
+                        if (ghostIsActorInEvent)
                         {
                             ReplaceObjectInTrigger(event->start_trigger_, object, ghost, -ghost->GetHeadstartTime(), event);
                         }
                         ghost->addEvent(event);
                     }
                 }
+            }
+            if (ghostIsActorInAct)
+            {
+                ReplaceObjectInTrigger(act->start_trigger_, object, ghost, -ghost->GetHeadstartTime());
             }
         }
     }


### PR DESCRIPTION
**Issue linked** https://github.com/esmini/esmini/issues/679

Context (x-post from the issue):
<details open>
In the SetupGhost function [here](https://github.com/esmini/esmini/blob/9dc23af113bee6554d0b7606f105be0e252b127b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.cpp#L1096), we call `ReplaceObjectInTrigger` for an `Event` if any `Action` of the `Event` is applicable for a ghost object, but for an `Act`, we always call `ReplaceObjectInTrigger` even when there is no `Action / Event` in the `Act` that applies to a ghost object. 

I know that in the esmini docs [here](https://esmini.github.io/) under the `Actions and Triggers` section, it is suggested that the SetupGhost functionality can be modified to the specific use-cases necessary, but in this case, I think it generally makes sense to only offset / replace the start triggers if the Act has any Action nested underneath it that applies to a ghost.

What this causes is the following:
For a scenario of the form:
```xml
     <Story name="Ego">
      <Act name="Act1">
        <ManeuverGroup maximumExecutionCount="1" name="Act1Group">
          <Actors selectTriggeringEntities="false">
            <EntityRef entityRef="ego" />
          </Actors>
        </ManeuverGroup>
        <StartTrigger>
          <ConditionGroup>
            <Condition name="TimeConditionEventActStart" delay="0" conditionEdge="none">
              <ByValueCondition>
                <SimulationTimeCondition value="0" rule="greaterThan" />
              </ByValueCondition>
            </Condition>
          </ConditionGroup>
        </StartTrigger>
        <StopTrigger>
          <ConditionGroup>
            <Condition name="TimeConditionEventActStop" delay="5" conditionEdge="none">
              <ByValueCondition>
                <StoryboardElementStateCondition storyboardElementType="act" state="startTransition" storyboardElementRef="Act1" />
              </ByValueCondition>
            </Condition>
          </ConditionGroup>
        </StopTrigger>
      </Act>
      <Act name="Act2">
        <ManeuverGroup maximumExecutionCount="1" name="Act2Group">
          <Actors selectTriggeringEntities="false">
            <EntityRef entityRef="ego" />
          </Actors>
          <Maneuver name="Manuever">
            <Event name="ParamActionEvent" priority="parallel">
              <Action name="MyParamAction">
                <GlobalAction>
                  <ParameterAction parameterRef="MyParameter">
                    <SetAction value="1" />
                  </ParameterAction>
                </GlobalAction>
              </Action>
              <StartTrigger>
                <ConditionGroup>
                  <Condition name="ParamActionEventCondition" delay="5" conditionEdge="none">
                    <ByValueCondition>
                      <StoryboardElementStateCondition storyboardElementType="act" state="startTransition" storyboardElementRef="Act1" />
                    </ByValueCondition>
                  </Condition>
                </ConditionGroup>
              </StartTrigger>
            </Event>
          </Maneuver>
        </ManeuverGroup>
      </Act>
    </Story>
```

If a ghost with a ghost headstart of 3 seconds, The Parameter Set Action will be applied at 2 seconds even with a 5 second delay specified due to the fact that `Act1`'s start trigger starts at -3 seconds instead of 0 seconds.

Will have a potential fix up soon, but curious on thoughts about the best way to fix this.
<details>

This PR modifies the SetupGhost to selectively replace the trigger for ghost when the Act contains an Event / Action that applies to a ghost agent instead of always replacing the triggers.