### PR TITLE
Fix crash when index used is larger than viewer entities_'s size in SteeringSensorSetVisible function

### DIFF
--- a/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp
+++ b/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp
@@ -1155,7 +1155,7 @@ void ScenarioPlayer::SteeringSensorSetVisible(int object_index, bool value)
     }
 
     int obj_index = scenarioEngine->entities_.GetObjectIdxById(object_index);
-    if (obj_index >= 0)
+    if (obj_index >= 0 && obj_index < static_cast<int>(viewer_->entities_.size()))
     {
         viewer::EntityModel* m = viewer_->entities_[static_cast<unsigned int>(obj_index)];
         if (m->IsMoving())


### PR DESCRIPTION
The SteeringSensorSetVisible function uses object_index to access viewer_->entities_,  but a race condition occurs when a new object is created in the scenario engine loop before the viewer's entity list is updated. This leads to object_index exceeding 
viewer_->entities_.size() and causes a crash.