### PR TITLE
Add camera interfaces

### DIFF
--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -2868,7 +2868,7 @@ extern "C"
 #ifdef _USE_OSG
         if (player && player->viewer_)
         {
-            return player->viewer_->GetEntityInFocus();
+            return SE_GetId(player->viewer_->GetEntityInFocus());
         }
 #endif
         return -1;

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -2886,11 +2886,18 @@ extern "C"
             *y = pos[1];
             *z = pos[2];
             *r = rot[0];
-            *h = rot[1];
-            *p = rot[2];
+            *p = rot[1];
+            *h = rot[2];
             return 0;
         }
-#endif
+#else
+        (void)x;
+        (void)y;
+        (void)z;
+        (void)h;
+        (void)p;
+        (void)r;
+#endif  // _USE_OSG
         return -1;
     }
 

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -2885,9 +2885,9 @@ extern "C"
             *x = pos[0];
             *y = pos[1];
             *z = pos[2];
-            *r = rot[0];
+            *h = rot[0];
             *p = rot[1];
-            *h = rot[2];
+            *r = rot[2];
             return 0;
         }
 #else

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -2874,6 +2874,26 @@ extern "C"
         return -1;
     }
 
+    SE_DLL_API int SE_GetCameraPos(float *x, float *y, float *z, float *h, float *p, float *r)
+    {
+#ifdef _USE_OSG
+        if (player && player->viewer_)
+        {
+            osg::Vec3 pos;
+            osg::Vec3 rot;
+            player->viewer_->GetCameraPosAndRot(pos, rot);
+            *x = pos[0];
+            *y = pos[1];
+            *z = pos[2];
+            *r = rot[0];
+            *h = rot[1];
+            *p = rot[2];
+            return 0;
+        }
+#endif
+        return -1;
+    }
+
     SE_DLL_API int SE_GetNumberOfRoutePoints(int object_id)
     {
         Object *obj = nullptr;

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -2863,6 +2863,17 @@ extern "C"
         return -1;
     }
 
+    SE_DLL_API int SE_GetObjectInCameraFocus()
+    {
+#ifdef _USE_OSG
+        if (player && player->viewer_)
+        {
+            return player->viewer_->GetEntityInFocus();
+        }
+#endif
+        return -1;
+    }
+
     SE_DLL_API int SE_GetNumberOfRoutePoints(int object_id)
     {
         Object *obj = nullptr;

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -1843,11 +1843,17 @@ extern "C"
     SE_DLL_API int SE_SetCameraMode(int mode);
 
     /**
-    Select camera mode
+    Sets the camera focus to the specified object 
     @param object_id The object to focus on
     @return 0 if successful, -1 if not
     */
     SE_DLL_API int SE_SetCameraObjectFocus(int object_id);
+
+    /**
+    Get the Id of the object the camera is focused on
+    @return Id of the object, -1 on error e.g. scenario not initialized or viewer not enabled
+    */
+    SE_DLL_API int SE_GetObjectInCameraFocus();
 
     /**
             Get the number Route points assigned for a specific vehicle

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -1843,7 +1843,7 @@ extern "C"
     SE_DLL_API int SE_SetCameraMode(int mode);
 
     /**
-    Sets the camera focus to the specified object 
+    Sets the camera focus to the specified object
     @param object_id The object to focus on
     @return 0 if successful, -1 if not
     */

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -1856,6 +1856,18 @@ extern "C"
     SE_DLL_API int SE_GetObjectInCameraFocus();
 
     /**
+    Get the position (x, y, z) and orientation (heading/yaw, pitch, roll) of the viewer camera
+    @param x reference to a variable returning the camera x coordinate
+    @param y reference to a variable returning the camera y coordinate
+    @param z reference to a variable returning the camera z coordinate
+    @param h reference to a variable returning the camera heading/yaw
+    @param p reference to a variable returning the camera pitch
+    @param r reference to a variable returning the camera roll
+    @return 0 if successful, -1 if not
+    */
+    SE_DLL_API int SE_GetCameraPos(float *x, float *y, float *z, float *h, float *p, float *r);
+
+    /**
             Get the number Route points assigned for a specific vehicle
             @param object_id The index of the vehicle
             @return number of Route points (0 means no route assigned), -1 on error


### PR DESCRIPTION
Added two new interfaces to esminiLib:

- `SE_GetObjectInCameraFocus()`: returns the ID of the object the viewer camera is currently focused on
- `SE_GetCameraPos()`: returns the viewer camera transform in global coordinates

I still need to make sure if I assigned the correct values from the `osg::Vec3 rot` to the arguments `h`, `p` and `r`.