### PR TITLE
OSMP FMU Feature Request/Implementation and Bug Fixes

### DIFF
--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
@@ -2611,7 +2611,7 @@ int OSIReporter::UpdateTrafficSignals()
 
 int OSIReporter::UpdateOSITrafficCommand()
 {
-    obj_osi_external.tc->clear_action();
+    obj_osi_external.tc->Clear();
 
     if (GetUDPClientStatus() == 0 || IsFileOpen())
     {
@@ -2621,7 +2621,7 @@ int OSIReporter::UpdateOSITrafficCommand()
 
     for (auto state_change : traffic_command_state_changes_)
     {
-        if (state_change.transition == StoryBoardElement::Transition::START_TRANSITION)
+        if (state_change.transition == StoryBoardElement::Transition::START_TRANSITION && state_change.state == StoryBoardElement::State::RUNNING)
         {
             ReportTrafficCommand(obj_osi_external.tc, state_change.action, scenario_engine_->getSimulationTime());
         }

--- a/OSMP_FMU/ExampleSystemStructure.ssd
+++ b/OSMP_FMU/ExampleSystemStructure.ssd
@@ -1,80 +1,93 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ssd:SystemStructureDescription version="1.0" name="Root-System" generationTool="orchideo | easySSP (eXXcellent solutions GmbH)" generationDateAndTime="2023-03-14T18:14:23Z" xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:easySSP="http://xsd.easy-ssp.com/SSPModel" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping">
+<ssd:SystemStructureDescription version="1.0" name="Root-System"
+    generationTool="orchideo | easySSP (eXXcellent solutions GmbH)"
+    generationDateAndTime="2023-03-14T18:14:23Z"
+    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+    xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+    xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+    xmlns:easySSP="http://xsd.easy-ssp.com/SSPModel"
+    xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+    xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping">
     <ssd:System name="Root-System">
         <ssd:ParameterBindings>
             <ssd:ParameterBinding>
                 <ssd:ParameterValues>
                     <ssv:ParameterSet version="1.0" name="Internal Parameter-Set">
-                        <ssv:Parameters/>
+                        <ssv:Parameters />
                     </ssv:ParameterSet>
                 </ssd:ParameterValues>
             </ssd:ParameterBinding>
         </ssd:ParameterBindings>
         <ssd:Elements>
-            <ssd:Component type="application/x-fmu-sharedlibrary" source="resources/OSMPDummySensor.fmu" implementation="CoSimulation" name="OSMP Dummy Sensor FMU" description="Demonstration C++ Sensor FMU for OSI Sensor Model Packaging">
+            <ssd:Component type="application/x-fmu-sharedlibrary"
+                source="resources/OSMPDummySensor.fmu" implementation="CoSimulation"
+                name="OSMP Dummy Sensor FMU"
+                description="Demonstration C++ Sensor FMU for OSI Sensor Model Packaging">
                 <ssd:Connectors>
                     <ssd:Connector name="OSMPSensorViewIn.base.lo" kind="input">
-                        <ssc:Integer/>
-                        <ssd:ConnectorGeometry x="0.0" y="0.75"/>
+                        <ssc:Integer />
+                        <ssd:ConnectorGeometry x="0.0" y="0.75" />
                     </ssd:Connector>
                     <ssd:Connector name="OSMPSensorViewIn.base.hi" kind="input">
-                        <ssc:Integer/>
-                        <ssd:ConnectorGeometry x="0.0" y="0.5"/>
+                        <ssc:Integer />
+                        <ssd:ConnectorGeometry x="0.0" y="0.5" />
                     </ssd:Connector>
                     <ssd:Connector name="OSMPSensorViewIn.size" kind="input">
-                        <ssc:Integer/>
-                        <ssd:ConnectorGeometry x="0.0" y="0.25"/>
+                        <ssc:Integer />
+                        <ssd:ConnectorGeometry x="0.0" y="0.25" />
                     </ssd:Connector>
                     <ssd:Connector name="OSMPSensorDataOut.base.lo" kind="output">
-                        <ssc:Integer/>
-                        <ssd:ConnectorGeometry x="1.0" y="0.75"/>
+                        <ssc:Integer />
+                        <ssd:ConnectorGeometry x="1.0" y="0.75" />
                     </ssd:Connector>
                     <ssd:Connector name="OSMPSensorDataOut.base.hi" kind="output">
-                        <ssc:Integer/>
-                        <ssd:ConnectorGeometry x="1.0" y="0.5"/>
+                        <ssc:Integer />
+                        <ssd:ConnectorGeometry x="1.0" y="0.5" />
                     </ssd:Connector>
                     <ssd:Connector name="OSMPSensorDataOut.size" kind="output">
-                        <ssc:Integer/>
-                        <ssd:ConnectorGeometry x="1.0" y="0.25"/>
+                        <ssc:Integer />
+                        <ssd:ConnectorGeometry x="1.0" y="0.25" />
                     </ssd:Connector>
                 </ssd:Connectors>
-                <ssd:ElementGeometry x1="-133.5" y1="-167.5" x2="147.5" y2="44.5"/>
+                <ssd:ElementGeometry x1="-133.5" y1="-167.5" x2="147.5" y2="44.5" />
                 <ssd:ParameterBindings>
                     <ssd:ParameterBinding>
                         <ssd:ParameterValues>
                             <ssv:ParameterSet version="1.0" name="Internal Parameter-Set">
-                                <ssv:Parameters/>
+                                <ssv:Parameters />
                             </ssv:ParameterSet>
                         </ssd:ParameterValues>
                     </ssd:ParameterBinding>
                 </ssd:ParameterBindings>
             </ssd:Component>
-            <ssd:Component type="application/x-fmu-sharedlibrary" source="resources/EsminiOsiSource.fmu" implementation="CoSimulation" name="esmini" description="esmini scnario player packaged as OSMP FMU outputting an osi3::SensorView with GoundTruth from the scenario">
+            <ssd:Component type="application/x-fmu-sharedlibrary"
+                source="resources/EsminiOsiSource.fmu" implementation="CoSimulation" name="esmini"
+                description="esmini scnario player packaged as OSMP FMU outputting an osi3::SensorView with GoundTruth from the scenario">
                 <ssd:Connectors>
                     <ssd:Connector name="OSMPSensorViewOut.base.lo" kind="output">
-                        <ssc:Integer/>
-                        <ssd:ConnectorGeometry x="1.0" y="0.75"/>
+                        <ssc:Integer />
+                        <ssd:ConnectorGeometry x="1.0" y="0.75" />
                     </ssd:Connector>
                     <ssd:Connector name="OSMPSensorViewOut.base.hi" kind="output">
-                        <ssc:Integer/>
-                        <ssd:ConnectorGeometry x="1.0" y="0.490625"/>
+                        <ssc:Integer />
+                        <ssd:ConnectorGeometry x="1.0" y="0.490625" />
                     </ssd:Connector>
                     <ssd:Connector name="OSMPSensorViewOut.size" kind="output">
-                        <ssc:Integer/>
-                        <ssd:ConnectorGeometry x="1.0" y="0.25"/>
+                        <ssc:Integer />
+                        <ssd:ConnectorGeometry x="1.0" y="0.25" />
                     </ssd:Connector>
                 </ssd:Connectors>
-                <ssd:ElementGeometry x1="-704.0" y1="-168.0" x2="-401.0" y2="51.0"/>
+                <ssd:ElementGeometry x1="-704.0" y1="-168.0" x2="-401.0" y2="51.0" />
                 <ssd:ParameterBindings>
                     <ssd:ParameterBinding>
                         <ssd:ParameterValues>
                             <ssv:ParameterSet version="1.0" name="Internal Parameter-Set">
                                 <ssv:Parameters>
                                     <ssv:Parameter name="xosc_path">
-                                        <ssv:String value="your/xosc/path.xosc"/>
+                                        <ssv:String value="your/xosc/path.xosc" />
                                     </ssv:Parameter>
                                     <ssv:Parameter name="use_viewer">
-                                        <ssv:Boolean value="true"/>
+                                        <ssv:Boolean value="true" />
                                     </ssv:Parameter>
                                 </ssv:Parameters>
                             </ssv:ParameterSet>
@@ -84,28 +97,34 @@
             </ssd:Component>
         </ssd:Elements>
         <ssd:Connections>
-            <ssd:Connection startElement="esmini" startConnector="OSMPSensorViewOut.base.lo" endElement="OSMP Dummy Sensor FMU" endConnector="OSMPSensorViewIn.base.lo" suppressUnitConversion="false"/>
-            <ssd:Connection startElement="esmini" startConnector="OSMPSensorViewOut.base.hi" endElement="OSMP Dummy Sensor FMU" endConnector="OSMPSensorViewIn.base.hi" suppressUnitConversion="false"/>
-            <ssd:Connection startElement="esmini" startConnector="OSMPSensorViewOut.size" endElement="OSMP Dummy Sensor FMU" endConnector="OSMPSensorViewIn.size" suppressUnitConversion="false"/>
+            <ssd:Connection startElement="esmini" startConnector="OSMPSensorViewOut.base.lo"
+                endElement="OSMP Dummy Sensor FMU" endConnector="OSMPSensorViewIn.base.lo"
+                suppressUnitConversion="false" />
+            <ssd:Connection startElement="esmini" startConnector="OSMPSensorViewOut.base.hi"
+                endElement="OSMP Dummy Sensor FMU" endConnector="OSMPSensorViewIn.base.hi"
+                suppressUnitConversion="false" />
+            <ssd:Connection startElement="esmini" startConnector="OSMPSensorViewOut.size"
+                endElement="OSMP Dummy Sensor FMU" endConnector="OSMPSensorViewIn.size"
+                suppressUnitConversion="false" />
         </ssd:Connections>
-        <ssd:SystemGeometry x1="-904.0" y1="-368.0" x2="347.5" y2="251.0"/>
+        <ssd:SystemGeometry x1="-904.0" y1="-368.0" x2="347.5" y2="251.0" />
     </ssd:System>
     <ssd:DefaultExperiment startTime="0.0">
         <ssd:Annotations>
             <!-- additional OpenMCx specific simulation parameters -->
             <ssc:Annotation type="com.avl.model.connect.ssp.task"
-                            xmlns:mc="com.avl.model.connect.ssp.task">
+                xmlns:mc="com.avl.model.connect.ssp.task">
                 <!-- sequential execution of component steps -->
                 <!-- synchronization time step size of 0.001 -->
-                <!-- simulation will end when the stopTime is reached -->
-                <mc:Task stepType="sequential" deltaTime="0.01" endType="first_component"/>
+                <!-- simulation will end when the first component is stopped -->
+                <mc:Task stepType="sequential" deltaTime="0.01" endType="first_component" />
             </ssc:Annotation>
         </ssd:Annotations>
     </ssd:DefaultExperiment>
     <ssd:Annotations>
         <ssc:Annotation type="com.easy-ssp.easy.ssp-model">
             <easySSP:ParameterVariants>
-                <easySSP:ParameterVariant name="Parameter-Variant" isBase="true"/>
+                <easySSP:ParameterVariant name="Parameter-Variant" isBase="true" />
             </easySSP:ParameterVariants>
         </ssc:Annotation>
     </ssd:Annotations>

--- a/OSMP_FMU/ExampleSystemStructure.ssd
+++ b/OSMP_FMU/ExampleSystemStructure.ssd
@@ -90,7 +90,7 @@
         </ssd:Connections>
         <ssd:SystemGeometry x1="-904.0" y1="-368.0" x2="347.5" y2="251.0"/>
     </ssd:System>
-    <ssd:DefaultExperiment startTime="0.0" stopTime="15.0">
+    <ssd:DefaultExperiment startTime="0.0">
         <ssd:Annotations>
             <!-- additional OpenMCx specific simulation parameters -->
             <ssc:Annotation type="com.avl.model.connect.ssp.task"
@@ -98,7 +98,7 @@
                 <!-- sequential execution of component steps -->
                 <!-- synchronization time step size of 0.001 -->
                 <!-- simulation will end when the stopTime is reached -->
-                <mc:Task stepType="sequential" deltaTime="0.01" endType="end_time"/>
+                <mc:Task stepType="sequential" deltaTime="0.01" endType="first_component"/>
             </ssc:Annotation>
         </ssd:Annotations>
     </ssd:DefaultExperiment>

--- a/OSMP_FMU/README.md
+++ b/OSMP_FMU/README.md
@@ -17,7 +17,8 @@ The SensorView is the output of the FMU. The FMU can be used in either open-loop
   cmake --build . --config Release
   ```
 - Run the FMU in a co-simulation, e.g. by using the open source framework [OpenMCx](https://github.com/eclipse/openmcx).
-Be sure to set the OpenScenario file as FMI parameter *xosc_path*.
+You may set the OpenScenario file as FMI parameter *xosc_path* or specify explicitly all esmini arguments as FMI parameter *esmini_args* (e.g. `--window 0 0 320 240 --capture_screen --fixed_timestep 0.05 --osc myscenario.xosc`).
+If both (*xosc_path* and *esmini_args*) are specified *esmini_args* will be used.
 Furthermore, you can set, if the scenario viewer is displayed with the boolean FMI parameter *use_viewer*.
 The esmini OSMP FMU can be used in either open-loop or closed-loop configuration.
   - Open-loop: Leave the osi3::TrafficUpdate input empty.

--- a/OSMP_FMU/esmini.cpp
+++ b/OSMP_FMU/esmini.cpp
@@ -206,7 +206,7 @@ fmi2Status EsminiOsiSource::doStart(fmi2Boolean toleranceDefined,
 {
     DEBUGBREAK();
 
-    slaveTerminated = false;
+    fmiSlaveTerminated = false;
 
     return fmi2OK;
 }
@@ -223,7 +223,6 @@ fmi2Status EsminiOsiSource::doExitInitializationMode()
     DEBUGBREAK();
 
     std::string esmini_args = fmi_esmini_args();
-    std::cerr << "Esmini args are \"" << esmini_args << "\"" << std::endl;
     if (esmini_args.empty())
     {
         const std::string xosc_path = fmi_xosc_path();
@@ -335,7 +334,7 @@ fmi2Status EsminiOsiSource::doCalc(fmi2Real currentCommunicationPoint, fmi2Real 
     set_fmi_valid(1);
     if (SE_GetQuitFlag() > 0) {
         normal_log("OSMP", ("esmini terminated with flag " + std::to_string(SE_GetQuitFlag()) + ". Terminating agent!").c_str());
-        slaveTerminated = true;
+        fmiSlaveTerminated = true;
         return fmi2Discard;
     }
 
@@ -508,7 +507,7 @@ fmi2Status EsminiOsiSource::Reset()
 {
     fmi_verbose_log("fmi2Reset()");
 
-    slaveTerminated = false;
+    fmiSlaveTerminated = false;
 
     doFree();
     return doInit();
@@ -842,7 +841,7 @@ extern "C"
     {
         if (s == fmi2StatusKind::fmi2Terminated) {
             EsminiOsiSource* myc = (EsminiOsiSource*)c;
-            *value = myc->slave_terminated() ? fmi2True : fmi2False;
+            *value = myc->get_slave_terminated() ? fmi2True : fmi2False;
             return fmi2OK;
         }
         return fmi2Discard;

--- a/OSMP_FMU/esmini.cpp
+++ b/OSMP_FMU/esmini.cpp
@@ -62,42 +62,46 @@ ofstream COSMPDummySource::private_log_file;
  * ProtocolBuffer Accessors
  */
 
-void* decode_integer_to_pointer(fmi2Integer hi,fmi2Integer lo)
+void* decode_integer_to_pointer(fmi2Integer hi, fmi2Integer lo)
 {
 #if PTRDIFF_MAX == INT64_MAX
-  union addrconv {
-    struct {
-      int lo;
-      int hi;
-    } base;
-    unsigned long long address;
-  } myaddr;
-  myaddr.base.lo=lo;
-  myaddr.base.hi=hi;
-  return reinterpret_cast<void*>(myaddr.address);
+    union addrconv
+    {
+        struct
+        {
+            int lo;
+            int hi;
+        } base;
+        unsigned long long address;
+    } myaddr;
+    myaddr.base.lo = lo;
+    myaddr.base.hi = hi;
+    return reinterpret_cast<void*>(myaddr.address);
 #elif PTRDIFF_MAX == INT32_MAX
-  return reinterpret_cast<void*>(lo);
+    return reinterpret_cast<void*>(lo);
 #else
 #error "Cannot determine 32bit or 64bit environment!"
 #endif
 }
 
-void encode_pointer_to_integer(const void* ptr,fmi2Integer& hi,fmi2Integer& lo)
+void encode_pointer_to_integer(const void* ptr, fmi2Integer& hi, fmi2Integer& lo)
 {
 #if PTRDIFF_MAX == INT64_MAX
-  union addrconv {
-    struct {
-      int lo;
-      int hi;
-    } base;
-    unsigned long long address;
-  } myaddr;
-  myaddr.address=reinterpret_cast<unsigned long long>(ptr);
-  hi=myaddr.base.hi;
-  lo=myaddr.base.lo;
+    union addrconv
+    {
+        struct
+        {
+            int lo;
+            int hi;
+        } base;
+        unsigned long long address;
+    } myaddr;
+    myaddr.address = reinterpret_cast<unsigned long long>(ptr);
+    hi             = myaddr.base.hi;
+    lo             = myaddr.base.lo;
 #elif PTRDIFF_MAX == INT32_MAX
-  hi=0;
-    lo=reinterpret_cast<int>(ptr);
+    hi = 0;
+    lo = reinterpret_cast<int>(ptr);
 #else
 #error "Cannot determine 32bit or 64bit environment!"
 #endif
@@ -105,12 +109,20 @@ void encode_pointer_to_integer(const void* ptr,fmi2Integer& hi,fmi2Integer& lo)
 
 bool EsminiOsiSource::get_fmi_traffic_update_in(osi3::TrafficUpdate& data)
 {
-    if (integer_vars[FMI_INTEGER_TRAFFICUPDATE_IN_SIZE_IDX] > 0) {
-        void* buffer = decode_integer_to_pointer(integer_vars[FMI_INTEGER_TRAFFICUPDATE_IN_BASEHI_IDX],integer_vars[FMI_INTEGER_TRAFFICUPDATE_IN_BASELO_IDX]);
-        normal_log("OSMP","Got %08X %08X, reading from %p ...",integer_vars[FMI_INTEGER_TRAFFICUPDATE_IN_BASEHI_IDX],integer_vars[FMI_INTEGER_TRAFFICUPDATE_IN_BASELO_IDX],buffer);
-        data.ParseFromArray(buffer,integer_vars[FMI_INTEGER_TRAFFICUPDATE_IN_SIZE_IDX]);
+    if (integer_vars[FMI_INTEGER_TRAFFICUPDATE_IN_SIZE_IDX] > 0)
+    {
+        void* buffer =
+            decode_integer_to_pointer(integer_vars[FMI_INTEGER_TRAFFICUPDATE_IN_BASEHI_IDX], integer_vars[FMI_INTEGER_TRAFFICUPDATE_IN_BASELO_IDX]);
+        normal_log("OSMP",
+                   "Got %08X %08X, reading from %p ...",
+                   integer_vars[FMI_INTEGER_TRAFFICUPDATE_IN_BASEHI_IDX],
+                   integer_vars[FMI_INTEGER_TRAFFICUPDATE_IN_BASELO_IDX],
+                   buffer);
+        data.ParseFromArray(buffer, integer_vars[FMI_INTEGER_TRAFFICUPDATE_IN_SIZE_IDX]);
         return true;
-    } else {
+    }
+    else
+    {
         return false;
     }
 }
@@ -119,34 +131,46 @@ void EsminiOsiSource::set_fmi_sensor_view_out(const osi3::SensorView& data)
 {
     string* buffer = new string();
     data.SerializeToString(buffer);
-    encode_pointer_to_integer(buffer->data(),integer_vars[FMI_INTEGER_SENSORVIEW_OUT_BASEHI_IDX],integer_vars[FMI_INTEGER_SENSORVIEW_OUT_BASELO_IDX]);
-    integer_vars[FMI_INTEGER_SENSORVIEW_OUT_SIZE_IDX]=(fmi2Integer)buffer->length();
-    normal_log("OSMP","Providing %08X %08X, writing from %p ...",integer_vars[FMI_INTEGER_SENSORVIEW_OUT_BASEHI_IDX],integer_vars[FMI_INTEGER_SENSORVIEW_OUT_BASELO_IDX],buffer->data());
+    encode_pointer_to_integer(buffer->data(),
+                              integer_vars[FMI_INTEGER_SENSORVIEW_OUT_BASEHI_IDX],
+                              integer_vars[FMI_INTEGER_SENSORVIEW_OUT_BASELO_IDX]);
+    integer_vars[FMI_INTEGER_SENSORVIEW_OUT_SIZE_IDX] = (fmi2Integer)buffer->length();
+    normal_log("OSMP",
+               "Providing %08X %08X, writing from %p ...",
+               integer_vars[FMI_INTEGER_SENSORVIEW_OUT_BASEHI_IDX],
+               integer_vars[FMI_INTEGER_SENSORVIEW_OUT_BASELO_IDX],
+               buffer->data());
     buffers.push_back(buffer);
 }
 
 void EsminiOsiSource::reset_fmi_sensor_view_out()
 {
-  integer_vars[FMI_INTEGER_SENSORVIEW_OUT_SIZE_IDX]=0;
-  integer_vars[FMI_INTEGER_SENSORVIEW_OUT_BASEHI_IDX]=0;
-  integer_vars[FMI_INTEGER_SENSORVIEW_OUT_BASELO_IDX]=0;
+    integer_vars[FMI_INTEGER_SENSORVIEW_OUT_SIZE_IDX]   = 0;
+    integer_vars[FMI_INTEGER_SENSORVIEW_OUT_BASEHI_IDX] = 0;
+    integer_vars[FMI_INTEGER_SENSORVIEW_OUT_BASELO_IDX] = 0;
 }
 
 void EsminiOsiSource::set_fmi_traffic_command_out(const osi3::TrafficCommand& data)
 {
     string* buffer = new string();
     data.SerializeToString(buffer);
-    encode_pointer_to_integer(buffer->data(),integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_BASEHI_IDX],integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_BASELO_IDX]);
-    integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_SIZE_IDX]=(fmi2Integer)buffer->length();
-    normal_log("OSMP","Providing %08X %08X, writing from %p ...",integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_BASEHI_IDX],integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_BASELO_IDX],buffer->data());
+    encode_pointer_to_integer(buffer->data(),
+                              integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_BASEHI_IDX],
+                              integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_BASELO_IDX]);
+    integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_SIZE_IDX] = (fmi2Integer)buffer->length();
+    normal_log("OSMP",
+               "Providing %08X %08X, writing from %p ...",
+               integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_BASEHI_IDX],
+               integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_BASELO_IDX],
+               buffer->data());
     buffers.push_back(buffer);
 }
 
 void EsminiOsiSource::reset_fmi_traffic_command_out()
 {
-    integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_SIZE_IDX]=0;
-    integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_BASEHI_IDX]=0;
-    integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_BASELO_IDX]=0;
+    integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_SIZE_IDX]   = 0;
+    integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_BASEHI_IDX] = 0;
+    integer_vars[FMI_INTEGER_TRAFFICCOMMAND_OUT_BASELO_IDX] = 0;
 }
 
 /*
@@ -155,147 +179,187 @@ void EsminiOsiSource::reset_fmi_traffic_command_out()
 
 fmi2Status EsminiOsiSource::doInit()
 {
-  DEBUGBREAK();
+    DEBUGBREAK();
 
-  /* Booleans */
-  for (int i = 0; i<FMI_BOOLEAN_VARS; i++)
-    boolean_vars[i] = fmi2False;
+    /* Booleans */
+    for (int i = 0; i < FMI_BOOLEAN_VARS; i++)
+        boolean_vars[i] = fmi2False;
 
-  /* Integers */
-  for (int i = 0; i<FMI_INTEGER_VARS; i++)
-    integer_vars[i] = 0;
+    /* Integers */
+    for (int i = 0; i < FMI_INTEGER_VARS; i++)
+        integer_vars[i] = 0;
 
-  /* Reals */
-  for (int i = 0; i<FMI_REAL_VARS; i++)
-    real_vars[i] = 0.0;
+    /* Reals */
+    for (int i = 0; i < FMI_REAL_VARS; i++)
+        real_vars[i] = 0.0;
 
-  /* Strings */
-  for (int i = 0; i<FMI_STRING_VARS; i++)
-    string_vars[i] = "";
+    /* Strings */
+    for (int i = 0; i < FMI_STRING_VARS; i++)
+        string_vars[i] = "";
 
-  return fmi2OK;
+    return fmi2OK;
 }
 
-fmi2Status EsminiOsiSource::doStart(fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime)
+fmi2Status EsminiOsiSource::doStart(fmi2Boolean toleranceDefined,
+                                    fmi2Real    tolerance,
+                                    fmi2Real    startTime,
+                                    fmi2Boolean stopTimeDefined,
+                                    fmi2Real    stopTime)
 {
-  DEBUGBREAK();
+    DEBUGBREAK();
 
-  return fmi2OK;
+    return fmi2OK;
 }
 
 fmi2Status EsminiOsiSource::doEnterInitializationMode()
 {
-  DEBUGBREAK();
+    DEBUGBREAK();
 
-  return fmi2OK;
+    return fmi2OK;
 }
 
 fmi2Status EsminiOsiSource::doExitInitializationMode()
 {
-  DEBUGBREAK();
+    DEBUGBREAK();
 
-  const std::string xosc_path =  fmi_xosc_path();
-  if (xosc_path.empty()) {
-    std::cerr << "No OpenScenario file selected!" << std::endl;
-    return fmi2Error;
-  }
-  if (SE_Init(xosc_path.c_str(), 0, fmi_use_viewer(), 0, 0) != 0)
-  {
-    std::cerr <<"Failed to initialize the scenario" << std::endl;
-    return fmi2Error;
-  }
+    std::string esmini_args = fmi_esmini_args();
+    std::cerr << "Esmini args are \"" << esmini_args << "\"" << std::endl;
+    if (esmini_args.empty())
+    {
+        const std::string xosc_path = fmi_xosc_path();
+        if (xosc_path.empty())
+        {
+            std::cerr << "No OpenScenario file selected!" << std::endl;
+            return fmi2Error;
+        }
+        if (SE_Init(xosc_path.c_str(), 0, fmi_use_viewer(), 0, 0) != 0)
+        {
+            std::cerr << "Failed to initialize the scenario" << std::endl;
+            return fmi2Error;
+        }
+    }
+    else
+    {
+        std::vector<std::string> args = {"esmini(lib)"};
+        size_t                   start = 0, end = 0;
+        while ((end = esmini_args.find(' ', start)) != size_t(-1))
+        {
+            args.push_back(esmini_args.substr(start, end - start));
+            start = end + 1;
+        }
+        args.push_back(esmini_args.substr(start).c_str());
+        int argc = static_cast<int>(args.size());
+        const char *argv[argc];
+        for (int i = 0; i < argc; i++) {
+            argv[i] = args.at(i).c_str();
+        }
+        if (SE_InitWithArgs(argc, argv) != 0)
+        {
+            std::cerr << "Failed to initialize the scenario" << std::endl;
+            return fmi2Error;
+        }
+    }
 
-  return fmi2OK;
+    return fmi2OK;
 }
 
 fmi2Status EsminiOsiSource::doCalc(fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPoint)
 {
-  DEBUGBREAK();
-  clear_buffers();
+    DEBUGBREAK();
+    clear_buffers();
 
-  // Handle OSI TrafficUpdate input
-  osi3::TrafficUpdate traffic_update;
-  if (get_fmi_traffic_update_in(traffic_update))
-  {
-    for (const auto& obj : traffic_update.update())
+    // Handle OSI TrafficUpdate input
+    osi3::TrafficUpdate traffic_update;
+    if (get_fmi_traffic_update_in(traffic_update))
     {
-      const int obj_id = (int)obj.id().value();
-      SE_ScenarioObjectState vehicleState;
-      SE_GetObjectState(obj_id, &vehicleState);
-      if (obj.base().has_orientation())
-      {
-        vehicleState.h = (float)obj.base().orientation().yaw();
-      }
+        for (const auto& obj : traffic_update.update())
+        {
+            const int              obj_id = (int)obj.id().value();
+            SE_ScenarioObjectState vehicleState;
+            SE_GetObjectState(obj_id, &vehicleState);
+            if (obj.base().has_orientation())
+            {
+                vehicleState.h = (float)obj.base().orientation().yaw();
+            }
 
-      if (obj.base().has_position())
-      {
-        vehicleState.x = obj.base().position().x() - vehicleState.centerOffsetX * cos(vehicleState.h) - vehicleState.centerOffsetY * sin(vehicleState.h);
-        vehicleState.y = obj.base().position().y() - vehicleState.centerOffsetX * sin(vehicleState.h) - vehicleState.centerOffsetY * cos(vehicleState.h);
-      }
+            if (obj.base().has_position())
+            {
+                vehicleState.x =
+                    obj.base().position().x() - vehicleState.centerOffsetX * cos(vehicleState.h) - vehicleState.centerOffsetY * sin(vehicleState.h);
+                vehicleState.y =
+                    obj.base().position().y() - vehicleState.centerOffsetX * sin(vehicleState.h) - vehicleState.centerOffsetY * cos(vehicleState.h);
+            }
 
-      SE_ReportObjectPosXYH(obj_id, 0, vehicleState.x, vehicleState.y, vehicleState.h);
+            SE_ReportObjectPosXYH(obj_id, 0, vehicleState.x, vehicleState.y, vehicleState.h);
 
-      if (obj.base().has_velocity())
-      {
-        SE_ReportObjectVel(obj_id, 0, obj.base().velocity().x(), obj.base().velocity().y(), obj.base().velocity().z());
-      }
+            if (obj.base().has_velocity())
+            {
+                SE_ReportObjectVel(obj_id, 0, obj.base().velocity().x(), obj.base().velocity().y(), obj.base().velocity().z());
+            }
+        }
     }
-  }
-  else
-  {
-    normal_log("OSMP","No TrafficUpdate received.");
-  }
+    else
+    {
+        normal_log("OSMP", "No TrafficUpdate received.");
+    }
 
-  SE_SetOSIStaticReportMode(SE_OSIStaticReportMode::API);
+    SE_SetOSIStaticReportMode(SE_OSIStaticReportMode::API);
 
-  // Run simulation step
-  if (SE_StepDT((float)communicationStepSize) != 0)
-  {
-    std::cerr <<"Failed run simulation step" << std::endl;
-    return fmi2Error;
-  }
+    // Run simulation step
+    if (SE_StepDT((float)communicationStepSize) != 0)
+    {
+        std::cerr << "Failed run simulation step" << std::endl;
+        return fmi2Error;
+    }
 
-  const auto* se_osi_ground_truth = reinterpret_cast<const osi3::GroundTruth*>(SE_GetOSIGroundTruthRaw()); //Fetch OSI struct
+    const auto* se_osi_ground_truth = reinterpret_cast<const osi3::GroundTruth*>(SE_GetOSIGroundTruthRaw());  // Fetch OSI struct
 
-  osi3::SensorView currentOut;
-  currentOut.Clear();
-  currentOut.mutable_sensor_id()->set_value(0);
-  currentOut.mutable_host_vehicle_id()->set_value(se_osi_ground_truth->host_vehicle_id().value());
-  double const time = currentCommunicationPoint+communicationStepSize;
-  currentOut.mutable_timestamp()->set_seconds((long long int)floor(time));
-  const double sec_to_nanos = 1000000000.0;
-  currentOut.mutable_timestamp()->set_nanos((int)((time - floor(time)) * sec_to_nanos));
-  osi3::GroundTruth *currentGT = currentOut.mutable_global_ground_truth();
-  currentGT->CopyFrom(*se_osi_ground_truth);
+    osi3::SensorView currentOut;
+    currentOut.Clear();
+    currentOut.mutable_sensor_id()->set_value(0);
+    currentOut.mutable_host_vehicle_id()->set_value(se_osi_ground_truth->host_vehicle_id().value());
+    double const time = currentCommunicationPoint + communicationStepSize;
+    currentOut.mutable_timestamp()->set_seconds((long long int)floor(time));
+    const double sec_to_nanos = 1000000000.0;
+    currentOut.mutable_timestamp()->set_nanos((int)((time - floor(time)) * sec_to_nanos));
+    osi3::GroundTruth* currentGT = currentOut.mutable_global_ground_truth();
+    currentGT->CopyFrom(*se_osi_ground_truth);
 
-  set_fmi_sensor_view_out(currentOut);
+    set_fmi_sensor_view_out(currentOut);
 
-  // Handle OSI TrafficCommand output
-  const auto* traffic_command = reinterpret_cast<const osi3::TrafficCommand*>(SE_GetOSITrafficCommandRaw()); // Fetch OSI struct (via pointer, no copying of data)
-  set_fmi_traffic_command_out(*traffic_command);
+    // Handle OSI TrafficCommand output
+    const auto* traffic_command =
+        reinterpret_cast<const osi3::TrafficCommand*>(SE_GetOSITrafficCommandRaw());  // Fetch OSI struct (via pointer, no copying of data)
+    set_fmi_traffic_command_out(*traffic_command);
 
-  set_fmi_valid(1);
-  set_quit_flag(SE_GetQuitFlag());
+    set_fmi_valid(1);
+    set_quit_flag(SE_GetQuitFlag());
 
-  return fmi2OK;
+    return fmi2OK;
 }
 
 fmi2Status EsminiOsiSource::doTerm()
 {
-  DEBUGBREAK();
-  return fmi2OK;
+    DEBUGBREAK();
+    return fmi2OK;
 }
 
 void EsminiOsiSource::doFree()
 {
-  DEBUGBREAK();
+    DEBUGBREAK();
 }
 
 /*
  * Generic C++ Wrapper Code
  */
 
-EsminiOsiSource::EsminiOsiSource(fmi2String theinstanceName, fmi2Type thefmuType, fmi2String thefmuGUID, fmi2String thefmuResourceLocation, const fmi2CallbackFunctions* thefunctions, fmi2Boolean thevisible, fmi2Boolean theloggingOn)
+EsminiOsiSource::EsminiOsiSource(fmi2String                   theinstanceName,
+                                 fmi2Type                     thefmuType,
+                                 fmi2String                   thefmuGUID,
+                                 fmi2String                   thefmuResourceLocation,
+                                 const fmi2CallbackFunctions* thefunctions,
+                                 fmi2Boolean                  thevisible,
+                                 fmi2Boolean                  theloggingOn)
     : instanceName(theinstanceName),
       fmuType(thefmuType),
       fmuGUID(thefmuGUID),
@@ -304,15 +368,18 @@ EsminiOsiSource::EsminiOsiSource(fmi2String theinstanceName, fmi2Type thefmuType
       visible(!!thevisible),
       loggingOn(!!theloggingOn)
 {
-  loggingCategories.clear();
-  loggingCategories.insert("FMI");
-  loggingCategories.insert("OSMP");
-  loggingCategories.insert("OSI");
+    //   currentBuffer = new string();
+    //   lastBuffer = new string();
+    loggingCategories.clear();
+    loggingCategories.insert("FMI");
+    loggingCategories.insert("OSMP");
+    loggingCategories.insert("OSI");
 }
 
 void EsminiOsiSource::clear_buffers()
 {
-    while (!buffers.empty()) {
+    while (!buffers.empty())
+    {
         string* el = buffers.back();
         buffers.pop_back();
         delete el;
@@ -326,422 +393,457 @@ EsminiOsiSource::~EsminiOsiSource()
 
 fmi2Status EsminiOsiSource::SetDebugLogging(fmi2Boolean theloggingOn, size_t nCategories, const fmi2String categories[])
 {
-  fmi_verbose_log("fmi2SetDebugLogging(%s)", theloggingOn ? "true" : "false");
-  loggingOn = theloggingOn ? true : false;
-  if (categories && (nCategories > 0)) {
-    loggingCategories.clear();
-    for (size_t i=0;i<nCategories;i++) {
-      if (0==strcmp(categories[i],"FMI"))
+    fmi_verbose_log("fmi2SetDebugLogging(%s)", theloggingOn ? "true" : "false");
+    loggingOn = theloggingOn ? true : false;
+    if (categories && (nCategories > 0))
+    {
+        loggingCategories.clear();
+        for (size_t i = 0; i < nCategories; i++)
+        {
+            if (0 == strcmp(categories[i], "FMI"))
+                loggingCategories.insert("FMI");
+            else if (0 == strcmp(categories[i], "OSMP"))
+                loggingCategories.insert("OSMP");
+            else if (0 == strcmp(categories[i], "OSI"))
+                loggingCategories.insert("OSI");
+        }
+    }
+    else
+    {
+        loggingCategories.clear();
         loggingCategories.insert("FMI");
-      else if (0==strcmp(categories[i],"OSMP"))
         loggingCategories.insert("OSMP");
-      else if (0==strcmp(categories[i],"OSI"))
         loggingCategories.insert("OSI");
     }
-  } else {
-    loggingCategories.clear();
-    loggingCategories.insert("FMI");
-    loggingCategories.insert("OSMP");
-    loggingCategories.insert("OSI");
-  }
-  return fmi2OK;
+    return fmi2OK;
 }
 
-fmi2Component EsminiOsiSource::Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2String fmuGUID, fmi2String fmuResourceLocation, const fmi2CallbackFunctions* functions, fmi2Boolean visible, fmi2Boolean loggingOn)
+fmi2Component EsminiOsiSource::Instantiate(fmi2String                   instanceName,
+                                           fmi2Type                     fmuType,
+                                           fmi2String                   fmuGUID,
+                                           fmi2String                   fmuResourceLocation,
+                                           const fmi2CallbackFunctions* functions,
+                                           fmi2Boolean                  visible,
+                                           fmi2Boolean                  loggingOn)
 {
-  EsminiOsiSource* myc = new EsminiOsiSource(instanceName, fmuType, fmuGUID, fmuResourceLocation, functions, visible, loggingOn);
+    EsminiOsiSource* myc = new EsminiOsiSource(instanceName, fmuType, fmuGUID, fmuResourceLocation, functions, visible, loggingOn);
 
-  if (myc == NULL) {
-    fmi_verbose_log_global("fmi2Instantiate(\"%s\",%d,\"%s\",\"%s\",\"%s\",%d,%d) = NULL (alloc failure)",
-                           instanceName, fmuType, fmuGUID,
-                           (fmuResourceLocation != NULL) ? fmuResourceLocation : "<NULL>",
-                           "FUNCTIONS", visible, loggingOn);
-    return NULL;
-  }
+    if (myc == NULL)
+    {
+        fmi_verbose_log_global("fmi2Instantiate(\"%s\",%d,\"%s\",\"%s\",\"%s\",%d,%d) = NULL (alloc failure)",
+                               instanceName,
+                               fmuType,
+                               fmuGUID,
+                               (fmuResourceLocation != NULL) ? fmuResourceLocation : "<NULL>",
+                               "FUNCTIONS",
+                               visible,
+                               loggingOn);
+        return NULL;
+    }
 
-  if (myc->doInit() != fmi2OK) {
-    fmi_verbose_log_global("fmi2Instantiate(\"%s\",%d,\"%s\",\"%s\",\"%s\",%d,%d) = NULL (doInit failure)",
-                           instanceName, fmuType, fmuGUID,
-                           (fmuResourceLocation != NULL) ? fmuResourceLocation : "<NULL>",
-                           "FUNCTIONS", visible, loggingOn);
-    delete myc;
-    return NULL;
-  }
-  else {
-    fmi_verbose_log_global("fmi2Instantiate(\"%s\",%d,\"%s\",\"%s\",\"%s\",%d,%d) = %p",
-                           instanceName, fmuType, fmuGUID,
-                           (fmuResourceLocation != NULL) ? fmuResourceLocation : "<NULL>",
-                           "FUNCTIONS", visible, loggingOn, myc);
-    return (fmi2Component)myc;
-  }
+    if (myc->doInit() != fmi2OK)
+    {
+        fmi_verbose_log_global("fmi2Instantiate(\"%s\",%d,\"%s\",\"%s\",\"%s\",%d,%d) = NULL (doInit failure)",
+                               instanceName,
+                               fmuType,
+                               fmuGUID,
+                               (fmuResourceLocation != NULL) ? fmuResourceLocation : "<NULL>",
+                               "FUNCTIONS",
+                               visible,
+                               loggingOn);
+        delete myc;
+        return NULL;
+    }
+    else
+    {
+        fmi_verbose_log_global("fmi2Instantiate(\"%s\",%d,\"%s\",\"%s\",\"%s\",%d,%d) = %p",
+                               instanceName,
+                               fmuType,
+                               fmuGUID,
+                               (fmuResourceLocation != NULL) ? fmuResourceLocation : "<NULL>",
+                               "FUNCTIONS",
+                               visible,
+                               loggingOn,
+                               myc);
+        return (fmi2Component)myc;
+    }
 }
 
-fmi2Status EsminiOsiSource::SetupExperiment(fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime)
+fmi2Status EsminiOsiSource::SetupExperiment(fmi2Boolean toleranceDefined,
+                                            fmi2Real    tolerance,
+                                            fmi2Real    startTime,
+                                            fmi2Boolean stopTimeDefined,
+                                            fmi2Real    stopTime)
 {
-  fmi_verbose_log("fmi2SetupExperiment(%d,%g,%g,%d,%g)", toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
-  return doStart(toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
+    fmi_verbose_log("fmi2SetupExperiment(%d,%g,%g,%d,%g)", toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
+    return doStart(toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
 }
 
 fmi2Status EsminiOsiSource::EnterInitializationMode()
 {
-  fmi_verbose_log("fmi2EnterInitializationMode()");
-  return doEnterInitializationMode();
+    fmi_verbose_log("fmi2EnterInitializationMode()");
+    return doEnterInitializationMode();
 }
 
 fmi2Status EsminiOsiSource::ExitInitializationMode()
 {
-  fmi_verbose_log("fmi2ExitInitializationMode()");
-  return doExitInitializationMode();
+    fmi_verbose_log("fmi2ExitInitializationMode()");
+    return doExitInitializationMode();
 }
 
-fmi2Status EsminiOsiSource::DoStep(fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPointfmi2Component)
+fmi2Status EsminiOsiSource::DoStep(fmi2Real    currentCommunicationPoint,
+                                   fmi2Real    communicationStepSize,
+                                   fmi2Boolean noSetFMUStatePriorToCurrentPointfmi2Component)
 {
-  fmi_verbose_log("fmi2DoStep(%g,%g,%d)", currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPointfmi2Component);
-  return doCalc(currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPointfmi2Component);
+    fmi_verbose_log("fmi2DoStep(%g,%g,%d)", currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPointfmi2Component);
+    return doCalc(currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPointfmi2Component);
 }
 
 fmi2Status EsminiOsiSource::Terminate()
 {
-  fmi_verbose_log("fmi2Terminate()");
-  return doTerm();
+    fmi_verbose_log("fmi2Terminate()");
+    return doTerm();
 }
 
 fmi2Status EsminiOsiSource::Reset()
 {
-  fmi_verbose_log("fmi2Reset()");
+    fmi_verbose_log("fmi2Reset()");
 
-  doFree();
-  return doInit();
+    doFree();
+    return doInit();
 }
 
 void EsminiOsiSource::FreeInstance()
 {
-  fmi_verbose_log("fmi2FreeInstance()");
-  doFree();
+    fmi_verbose_log("fmi2FreeInstance()");
+    doFree();
 }
 
 fmi2Status EsminiOsiSource::GetReal(const fmi2ValueReference vr[], size_t nvr, fmi2Real value[])
 {
-  fmi_verbose_log("fmi2GetReal(...)");
-  for (size_t i = 0; i<nvr; i++) {
-    if (vr[i]<FMI_REAL_VARS)
-      value[i] = real_vars[vr[i]];
-    else
-      return fmi2Error;
-  }
-  return fmi2OK;
+    fmi_verbose_log("fmi2GetReal(...)");
+    for (size_t i = 0; i < nvr; i++)
+    {
+        if (vr[i] < FMI_REAL_VARS)
+            value[i] = real_vars[vr[i]];
+        else
+            return fmi2Error;
+    }
+    return fmi2OK;
 }
 
 fmi2Status EsminiOsiSource::GetInteger(const fmi2ValueReference vr[], size_t nvr, fmi2Integer value[])
 {
-  fmi_verbose_log("fmi2GetInteger(...)");
-  for (size_t i = 0; i<nvr; i++) {
-    if (vr[i]<FMI_INTEGER_VARS)
-      value[i] = integer_vars[vr[i]];
-    else
-      return fmi2Error;
-  }
-  return fmi2OK;
+    fmi_verbose_log("fmi2GetInteger(...)");
+    for (size_t i = 0; i < nvr; i++)
+    {
+        if (vr[i] < FMI_INTEGER_VARS)
+            value[i] = integer_vars[vr[i]];
+        else
+            return fmi2Error;
+    }
+    return fmi2OK;
 }
 
 fmi2Status EsminiOsiSource::GetBoolean(const fmi2ValueReference vr[], size_t nvr, fmi2Boolean value[])
 {
-  fmi_verbose_log("fmi2GetBoolean(...)");
-  for (size_t i = 0; i<nvr; i++) {
-    if (vr[i]<FMI_BOOLEAN_VARS)
-      value[i] = boolean_vars[vr[i]];
-    else
-      return fmi2Error;
-  }
-  return fmi2OK;
+    fmi_verbose_log("fmi2GetBoolean(...)");
+    for (size_t i = 0; i < nvr; i++)
+    {
+        if (vr[i] < FMI_BOOLEAN_VARS)
+            value[i] = boolean_vars[vr[i]];
+        else
+            return fmi2Error;
+    }
+    return fmi2OK;
 }
 
 fmi2Status EsminiOsiSource::GetString(const fmi2ValueReference vr[], size_t nvr, fmi2String value[])
 {
-  fmi_verbose_log("fmi2GetString(...)");
-  for (size_t i = 0; i<nvr; i++) {
-    if (vr[i]<FMI_STRING_VARS)
-      value[i] = string_vars[vr[i]].c_str();
-    else
-      return fmi2Error;
-  }
-  return fmi2OK;
+    fmi_verbose_log("fmi2GetString(...)");
+    for (size_t i = 0; i < nvr; i++)
+    {
+        if (vr[i] < FMI_STRING_VARS)
+            value[i] = string_vars[vr[i]].c_str();
+        else
+            return fmi2Error;
+    }
+    return fmi2OK;
 }
 
 fmi2Status EsminiOsiSource::SetReal(const fmi2ValueReference vr[], size_t nvr, const fmi2Real value[])
 {
-  fmi_verbose_log("fmi2SetReal(...)");
-  for (size_t i = 0; i<nvr; i++) {
-    if (vr[i]<FMI_REAL_VARS)
-      real_vars[vr[i]] = value[i];
-    else
-      return fmi2Error;
-  }
-  return fmi2OK;
+    fmi_verbose_log("fmi2SetReal(...)");
+    for (size_t i = 0; i < nvr; i++)
+    {
+        if (vr[i] < FMI_REAL_VARS)
+            real_vars[vr[i]] = value[i];
+        else
+            return fmi2Error;
+    }
+    return fmi2OK;
 }
 
 fmi2Status EsminiOsiSource::SetInteger(const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[])
 {
-  fmi_verbose_log("fmi2SetInteger(...)");
-  for (size_t i = 0; i<nvr; i++) {
-    if (vr[i]<FMI_INTEGER_VARS)
-      integer_vars[vr[i]] = value[i];
-    else
-      return fmi2Error;
-  }
-  return fmi2OK;
+    fmi_verbose_log("fmi2SetInteger(...)");
+    for (size_t i = 0; i < nvr; i++)
+    {
+        if (vr[i] < FMI_INTEGER_VARS)
+            integer_vars[vr[i]] = value[i];
+        else
+            return fmi2Error;
+    }
+    return fmi2OK;
 }
 
 fmi2Status EsminiOsiSource::SetBoolean(const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[])
 {
-  fmi_verbose_log("fmi2SetBoolean(...)");
-  for (size_t i = 0; i<nvr; i++) {
-    if (vr[i]<FMI_BOOLEAN_VARS)
-      boolean_vars[vr[i]] = value[i];
-    else
-      return fmi2Error;
-  }
-  return fmi2OK;
+    fmi_verbose_log("fmi2SetBoolean(...)");
+    for (size_t i = 0; i < nvr; i++)
+    {
+        if (vr[i] < FMI_BOOLEAN_VARS)
+            boolean_vars[vr[i]] = value[i];
+        else
+            return fmi2Error;
+    }
+    return fmi2OK;
 }
 
 fmi2Status EsminiOsiSource::SetString(const fmi2ValueReference vr[], size_t nvr, const fmi2String value[])
 {
-  fmi_verbose_log("fmi2SetString(...)");
-  for (size_t i = 0; i<nvr; i++) {
-    if (vr[i]<FMI_STRING_VARS)
-      string_vars[vr[i]] = value[i];
-    else
-      return fmi2Error;
-  }
-  return fmi2OK;
+    fmi_verbose_log("fmi2SetString(...)");
+    for (size_t i = 0; i < nvr; i++)
+    {
+        if (vr[i] < FMI_STRING_VARS)
+            string_vars[vr[i]] = value[i];
+        else
+            return fmi2Error;
+    }
+    return fmi2OK;
 }
 
 /*
  * FMI 2.0 Co-Simulation Interface API
  */
 
-extern "C" {
-
-FMI2_Export const char* fmi2GetTypesPlatform()
+extern "C"
 {
-  return fmi2TypesPlatform;
-}
+    FMI2_Export const char* fmi2GetTypesPlatform()
+    {
+        return fmi2TypesPlatform;
+    }
 
-FMI2_Export const char* fmi2GetVersion()
-{
-  return fmi2Version;
-}
+    FMI2_Export const char* fmi2GetVersion()
+    {
+        return fmi2Version;
+    }
 
-FMI2_Export fmi2Status fmi2SetDebugLogging(fmi2Component c, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[])
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->SetDebugLogging(loggingOn, nCategories, categories);
-}
+    FMI2_Export fmi2Status fmi2SetDebugLogging(fmi2Component c, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[])
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->SetDebugLogging(loggingOn, nCategories, categories);
+    }
 
-/*
-* Functions for Co-Simulation
-*/
-FMI2_Export fmi2Component fmi2Instantiate(fmi2String instanceName,
-fmi2Type fmuType,
-    fmi2String fmuGUID,
-fmi2String fmuResourceLocation,
-const fmi2CallbackFunctions* functions,
-    fmi2Boolean visible,
-fmi2Boolean loggingOn)
-{
-return EsminiOsiSource::Instantiate(instanceName, fmuType, fmuGUID, fmuResourceLocation, functions, visible, loggingOn);
-}
+    /*
+     * Functions for Co-Simulation
+     */
+    FMI2_Export fmi2Component fmi2Instantiate(fmi2String                   instanceName,
+                                              fmi2Type                     fmuType,
+                                              fmi2String                   fmuGUID,
+                                              fmi2String                   fmuResourceLocation,
+                                              const fmi2CallbackFunctions* functions,
+                                              fmi2Boolean                  visible,
+                                              fmi2Boolean                  loggingOn)
+    {
+        return EsminiOsiSource::Instantiate(instanceName, fmuType, fmuGUID, fmuResourceLocation, functions, visible, loggingOn);
+    }
 
-FMI2_Export fmi2Status fmi2SetupExperiment(fmi2Component c,
-fmi2Boolean toleranceDefined,
-    fmi2Real tolerance,
-fmi2Real startTime,
-    fmi2Boolean stopTimeDefined,
-fmi2Real stopTime)
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->SetupExperiment(toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
-}
+    FMI2_Export fmi2Status fmi2SetupExperiment(fmi2Component c,
+                                               fmi2Boolean   toleranceDefined,
+                                               fmi2Real      tolerance,
+                                               fmi2Real      startTime,
+                                               fmi2Boolean   stopTimeDefined,
+                                               fmi2Real      stopTime)
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->SetupExperiment(toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
+    }
 
-FMI2_Export fmi2Status fmi2EnterInitializationMode(fmi2Component c)
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->EnterInitializationMode();
-}
+    FMI2_Export fmi2Status fmi2EnterInitializationMode(fmi2Component c)
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->EnterInitializationMode();
+    }
 
-FMI2_Export fmi2Status fmi2ExitInitializationMode(fmi2Component c)
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->ExitInitializationMode();
-}
+    FMI2_Export fmi2Status fmi2ExitInitializationMode(fmi2Component c)
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->ExitInitializationMode();
+    }
 
-FMI2_Export fmi2Status fmi2DoStep(fmi2Component c,
-fmi2Real currentCommunicationPoint,
-    fmi2Real communicationStepSize,
-fmi2Boolean noSetFMUStatePriorToCurrentPointfmi2Component)
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->DoStep(currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPointfmi2Component);
-}
+    FMI2_Export fmi2Status fmi2DoStep(fmi2Component c,
+                                      fmi2Real      currentCommunicationPoint,
+                                      fmi2Real      communicationStepSize,
+                                      fmi2Boolean   noSetFMUStatePriorToCurrentPointfmi2Component)
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->DoStep(currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPointfmi2Component);
+    }
 
-FMI2_Export fmi2Status fmi2Terminate(fmi2Component c)
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->Terminate();
-}
+    FMI2_Export fmi2Status fmi2Terminate(fmi2Component c)
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->Terminate();
+    }
 
-FMI2_Export fmi2Status fmi2Reset(fmi2Component c)
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->Reset();
-}
+    FMI2_Export fmi2Status fmi2Reset(fmi2Component c)
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->Reset();
+    }
 
-FMI2_Export void fmi2FreeInstance(fmi2Component c)
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-myc->FreeInstance();
-delete myc;
-}
+    FMI2_Export void fmi2FreeInstance(fmi2Component c)
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        myc->FreeInstance();
+        delete myc;
+    }
 
-/*
- * Data Exchange Functions
- */
-FMI2_Export fmi2Status fmi2GetReal(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Real value[])
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->GetReal(vr, nvr, value);
-}
+    /*
+     * Data Exchange Functions
+     */
+    FMI2_Export fmi2Status fmi2GetReal(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Real value[])
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->GetReal(vr, nvr, value);
+    }
 
-FMI2_Export fmi2Status fmi2GetInteger(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Integer value[])
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->GetInteger(vr, nvr, value);
-}
+    FMI2_Export fmi2Status fmi2GetInteger(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Integer value[])
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->GetInteger(vr, nvr, value);
+    }
 
-FMI2_Export fmi2Status fmi2GetBoolean(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Boolean value[])
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->GetBoolean(vr, nvr, value);
-}
+    FMI2_Export fmi2Status fmi2GetBoolean(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Boolean value[])
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->GetBoolean(vr, nvr, value);
+    }
 
-FMI2_Export fmi2Status fmi2GetString(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2String value[])
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->GetString(vr, nvr, value);
-}
+    FMI2_Export fmi2Status fmi2GetString(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2String value[])
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->GetString(vr, nvr, value);
+    }
 
-FMI2_Export fmi2Status fmi2SetReal(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Real value[])
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->SetReal(vr, nvr, value);
-}
+    FMI2_Export fmi2Status fmi2SetReal(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Real value[])
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->SetReal(vr, nvr, value);
+    }
 
-FMI2_Export fmi2Status fmi2SetInteger(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[])
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->SetInteger(vr, nvr, value);
-}
+    FMI2_Export fmi2Status fmi2SetInteger(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[])
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->SetInteger(vr, nvr, value);
+    }
 
-FMI2_Export fmi2Status fmi2SetBoolean(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[])
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->SetBoolean(vr, nvr, value);
-}
+    FMI2_Export fmi2Status fmi2SetBoolean(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[])
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->SetBoolean(vr, nvr, value);
+    }
 
-FMI2_Export fmi2Status fmi2SetString(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2String value[])
-{
-EsminiOsiSource* myc = (EsminiOsiSource*)c;
-return myc->SetString(vr, nvr, value);
-}
+    FMI2_Export fmi2Status fmi2SetString(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2String value[])
+    {
+        EsminiOsiSource* myc = (EsminiOsiSource*)c;
+        return myc->SetString(vr, nvr, value);
+    }
 
-/*
- * Unsupported Features (FMUState, Derivatives, Async DoStep, Status Enquiries)
- */
-FMI2_Export fmi2Status fmi2GetFMUstate(fmi2Component c, fmi2FMUstate* FMUstate)
-{
-return fmi2Error;
-}
+    /*
+     * Unsupported Features (FMUState, Derivatives, Async DoStep, Status Enquiries)
+     */
+    FMI2_Export fmi2Status fmi2GetFMUstate(fmi2Component c, fmi2FMUstate* FMUstate)
+    {
+        return fmi2Error;
+    }
 
-FMI2_Export fmi2Status fmi2SetFMUstate(fmi2Component c, fmi2FMUstate FMUstate)
-{
-return fmi2Error;
-}
+    FMI2_Export fmi2Status fmi2SetFMUstate(fmi2Component c, fmi2FMUstate FMUstate)
+    {
+        return fmi2Error;
+    }
 
-FMI2_Export fmi2Status fmi2FreeFMUstate(fmi2Component c, fmi2FMUstate* FMUstate)
-{
-return fmi2Error;
-}
+    FMI2_Export fmi2Status fmi2FreeFMUstate(fmi2Component c, fmi2FMUstate* FMUstate)
+    {
+        return fmi2Error;
+    }
 
-FMI2_Export fmi2Status fmi2SerializedFMUstateSize(fmi2Component c, fmi2FMUstate FMUstate, size_t *size)
-{
-return fmi2Error;
-}
+    FMI2_Export fmi2Status fmi2SerializedFMUstateSize(fmi2Component c, fmi2FMUstate FMUstate, size_t* size)
+    {
+        return fmi2Error;
+    }
 
-FMI2_Export fmi2Status fmi2SerializeFMUstate (fmi2Component c, fmi2FMUstate FMUstate, fmi2Byte serializedState[], size_t size)
-{
-return fmi2Error;
-}
+    FMI2_Export fmi2Status fmi2SerializeFMUstate(fmi2Component c, fmi2FMUstate FMUstate, fmi2Byte serializedState[], size_t size)
+    {
+        return fmi2Error;
+    }
 
-FMI2_Export fmi2Status fmi2DeSerializeFMUstate (fmi2Component c, const fmi2Byte serializedState[], size_t size, fmi2FMUstate* FMUstate)
-{
-return fmi2Error;
-}
+    FMI2_Export fmi2Status fmi2DeSerializeFMUstate(fmi2Component c, const fmi2Byte serializedState[], size_t size, fmi2FMUstate* FMUstate)
+    {
+        return fmi2Error;
+    }
 
-FMI2_Export fmi2Status fmi2GetDirectionalDerivative(fmi2Component c,
-const fmi2ValueReference vUnknown_ref[], size_t nUnknown,
-const fmi2ValueReference vKnown_ref[] , size_t nKnown,
-const fmi2Real dvKnown[],
-    fmi2Real dvUnknown[])
-{
-return fmi2Error;
-}
+    FMI2_Export fmi2Status fmi2GetDirectionalDerivative(fmi2Component            c,
+                                                        const fmi2ValueReference vUnknown_ref[],
+                                                        size_t                   nUnknown,
+                                                        const fmi2ValueReference vKnown_ref[],
+                                                        size_t                   nKnown,
+                                                        const fmi2Real           dvKnown[],
+                                                        fmi2Real                 dvUnknown[])
+    {
+        return fmi2Error;
+    }
 
-FMI2_Export fmi2Status fmi2SetRealInputDerivatives(fmi2Component c,
-const  fmi2ValueReference vr[],
-    size_t nvr,
-const  fmi2Integer order[],
-const  fmi2Real value[])
-{
-return fmi2Error;
-}
+    FMI2_Export fmi2Status
+    fmi2SetRealInputDerivatives(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Integer order[], const fmi2Real value[])
+    {
+        return fmi2Error;
+    }
 
-FMI2_Export fmi2Status fmi2GetRealOutputDerivatives(fmi2Component c,
-const   fmi2ValueReference vr[],
-    size_t  nvr,
-const   fmi2Integer order[],
-    fmi2Real value[])
-{
-return fmi2Error;
-}
+    FMI2_Export fmi2Status
+    fmi2GetRealOutputDerivatives(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Integer order[], fmi2Real value[])
+    {
+        return fmi2Error;
+    }
 
-FMI2_Export fmi2Status fmi2CancelStep(fmi2Component c)
-{
-return fmi2OK;
-}
+    FMI2_Export fmi2Status fmi2CancelStep(fmi2Component c)
+    {
+        return fmi2OK;
+    }
 
-FMI2_Export fmi2Status fmi2GetStatus(fmi2Component c, const fmi2StatusKind s, fmi2Status* value)
-{
-return fmi2Discard;
-}
+    FMI2_Export fmi2Status fmi2GetStatus(fmi2Component c, const fmi2StatusKind s, fmi2Status* value)
+    {
+        return fmi2Discard;
+    }
 
-FMI2_Export fmi2Status fmi2GetRealStatus(fmi2Component c, const fmi2StatusKind s, fmi2Real* value)
-{
-return fmi2Discard;
-}
+    FMI2_Export fmi2Status fmi2GetRealStatus(fmi2Component c, const fmi2StatusKind s, fmi2Real* value)
+    {
+        return fmi2Discard;
+    }
 
-FMI2_Export fmi2Status fmi2GetIntegerStatus(fmi2Component c, const fmi2StatusKind s, fmi2Integer* value)
-{
-return fmi2Discard;
-}
+    FMI2_Export fmi2Status fmi2GetIntegerStatus(fmi2Component c, const fmi2StatusKind s, fmi2Integer* value)
+    {
+        return fmi2Discard;
+    }
 
-FMI2_Export fmi2Status fmi2GetBooleanStatus(fmi2Component c, const fmi2StatusKind s, fmi2Boolean* value)
-{
-return fmi2Discard;
-}
+    FMI2_Export fmi2Status fmi2GetBooleanStatus(fmi2Component c, const fmi2StatusKind s, fmi2Boolean* value)
+    {
+        return fmi2Discard;
+    }
 
-FMI2_Export fmi2Status fmi2GetStringStatus(fmi2Component c, const fmi2StatusKind s, fmi2String* value)
-{
-return fmi2Discard;
-}
-
+    FMI2_Export fmi2Status fmi2GetStringStatus(fmi2Component c, const fmi2StatusKind s, fmi2String* value)
+    {
+        return fmi2Discard;
+    }
 }

--- a/OSMP_FMU/esmini.h
+++ b/OSMP_FMU/esmini.h
@@ -61,7 +61,8 @@ using namespace std;
 #define FMI_INTEGER_TRAFFICCOMMAND_OUT_BASELO_IDX 9
 #define FMI_INTEGER_TRAFFICCOMMAND_OUT_BASEHI_IDX 10
 #define FMI_INTEGER_TRAFFICCOMMAND_OUT_SIZE_IDX 11
-#define FMI_INTEGER_LAST_IDX FMI_INTEGER_TRAFFICCOMMAND_OUT_SIZE_IDX
+#define FMI_INTEGER_QUIT_FLAG_IDX 12
+#define FMI_INTEGER_LAST_IDX FMI_INTEGER_QUIT_FLAG_IDX
 #define FMI_INTEGER_VARS (FMI_INTEGER_LAST_IDX+1)
 
 /* Real Variables */
@@ -202,12 +203,13 @@ protected:
     fmi2Integer integer_vars[FMI_INTEGER_VARS];
     fmi2Real real_vars[FMI_REAL_VARS];
     string string_vars[FMI_STRING_VARS];
-    string* currentBuffer;
-    string* lastBuffer;
+    std::vector<string*> buffers;
 
     /* Simple Accessors */
     fmi2Boolean fmi_valid() { return boolean_vars[FMI_BOOLEAN_VALID_IDX]; }
     void set_fmi_valid(fmi2Boolean value) { boolean_vars[FMI_BOOLEAN_VALID_IDX]=value; }
+    fmi2Integer quit_flag() { return integer_vars[FMI_INTEGER_QUIT_FLAG_IDX]; }
+    void set_quit_flag(fmi2Integer value) { integer_vars[FMI_INTEGER_QUIT_FLAG_IDX]=value; }
     fmi2Boolean fmi_use_viewer() { return boolean_vars[FMI_BOOLEAN_USE_VIEWER_IDX]; }
     void set_fmi_use_viewer(fmi2Boolean value) { boolean_vars[FMI_BOOLEAN_USE_VIEWER_IDX]=value; }
     string fmi_xosc_path() { return string_vars[FMI_STRING_XOSC_PATH_IDX]; }
@@ -220,4 +222,5 @@ protected:
     //bool get_fmi_traffic_command_update_in(osi3::TrafficCommandUpdate& data);     //TODO: Wait for OSI update
     void set_fmi_traffic_command_out(const osi3::TrafficCommand& data);
     void reset_fmi_traffic_command_out();
+    void clear_buffers();
 };

--- a/OSMP_FMU/esmini.h
+++ b/OSMP_FMU/esmini.h
@@ -109,6 +109,7 @@ public:
     fmi2Status SetInteger(const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[]);
     fmi2Status SetBoolean(const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[]);
     fmi2Status SetString(const fmi2ValueReference vr[], size_t nvr, const fmi2String value[]);
+    bool slave_terminated() { return slaveTerminated; };
 
 protected:
     /* Internal Implementation */
@@ -198,13 +199,17 @@ protected:
     string fmuResourceLocation;
     bool visible;
     bool loggingOn;
+    bool slaveTerminated;
     set<string> loggingCategories;
     fmi2CallbackFunctions functions;
     fmi2Boolean boolean_vars[FMI_BOOLEAN_VARS];
     fmi2Integer integer_vars[FMI_INTEGER_VARS];
     fmi2Real real_vars[FMI_REAL_VARS];
     string string_vars[FMI_STRING_VARS];
-    std::vector<string*> buffers;
+    string* currentBufferSVOut;
+    string* lastBufferSVOut;
+    string* currentBufferTCOut;
+    string* lastBufferTCOut;
 
     /* Simple Accessors */
     fmi2Boolean fmi_valid() { return boolean_vars[FMI_BOOLEAN_VALID_IDX]; }
@@ -225,5 +230,4 @@ protected:
     //bool get_fmi_traffic_command_update_in(osi3::TrafficCommandUpdate& data);     //TODO: Wait for OSI update
     void set_fmi_traffic_command_out(const osi3::TrafficCommand& data);
     void reset_fmi_traffic_command_out();
-    void clear_buffers();
 };

--- a/OSMP_FMU/esmini.h
+++ b/OSMP_FMU/esmini.h
@@ -61,8 +61,7 @@ using namespace std;
 #define FMI_INTEGER_TRAFFICCOMMAND_OUT_BASELO_IDX 9
 #define FMI_INTEGER_TRAFFICCOMMAND_OUT_BASEHI_IDX 10
 #define FMI_INTEGER_TRAFFICCOMMAND_OUT_SIZE_IDX 11
-#define FMI_INTEGER_QUIT_FLAG_IDX 12
-#define FMI_INTEGER_LAST_IDX FMI_INTEGER_QUIT_FLAG_IDX
+#define FMI_INTEGER_LAST_IDX FMI_INTEGER_TRAFFICCOMMAND_OUT_SIZE_IDX
 #define FMI_INTEGER_VARS (FMI_INTEGER_LAST_IDX+1)
 
 /* Real Variables */
@@ -109,7 +108,7 @@ public:
     fmi2Status SetInteger(const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[]);
     fmi2Status SetBoolean(const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[]);
     fmi2Status SetString(const fmi2ValueReference vr[], size_t nvr, const fmi2String value[]);
-    bool slave_terminated() { return slaveTerminated; };
+    bool get_slave_terminated() { return fmiSlaveTerminated; };
 
 protected:
     /* Internal Implementation */
@@ -199,7 +198,7 @@ protected:
     string fmuResourceLocation;
     bool visible;
     bool loggingOn;
-    bool slaveTerminated;
+    bool fmiSlaveTerminated;
     set<string> loggingCategories;
     fmi2CallbackFunctions functions;
     fmi2Boolean boolean_vars[FMI_BOOLEAN_VARS];
@@ -214,8 +213,6 @@ protected:
     /* Simple Accessors */
     fmi2Boolean fmi_valid() { return boolean_vars[FMI_BOOLEAN_VALID_IDX]; }
     void set_fmi_valid(fmi2Boolean value) { boolean_vars[FMI_BOOLEAN_VALID_IDX]=value; }
-    fmi2Integer quit_flag() { return integer_vars[FMI_INTEGER_QUIT_FLAG_IDX]; }
-    void set_quit_flag(fmi2Integer value) { integer_vars[FMI_INTEGER_QUIT_FLAG_IDX]=value; }
     fmi2Boolean fmi_use_viewer() { return boolean_vars[FMI_BOOLEAN_USE_VIEWER_IDX]; }
     void set_fmi_use_viewer(fmi2Boolean value) { boolean_vars[FMI_BOOLEAN_USE_VIEWER_IDX]=value; }
     string fmi_xosc_path() { return string_vars[FMI_STRING_XOSC_PATH_IDX]; }

--- a/OSMP_FMU/esmini.h
+++ b/OSMP_FMU/esmini.h
@@ -71,7 +71,8 @@ using namespace std;
 
 /* String Variables */
 #define FMI_STRING_XOSC_PATH_IDX 0
-#define FMI_STRING_LAST_IDX FMI_STRING_XOSC_PATH_IDX
+#define FMI_STRING_ESMINI_ARGS_IDX 1
+#define FMI_STRING_LAST_IDX FMI_STRING_ESMINI_ARGS_IDX
 #define FMI_STRING_VARS (FMI_STRING_LAST_IDX+1)
 
 #include <iostream>
@@ -214,6 +215,8 @@ protected:
     void set_fmi_use_viewer(fmi2Boolean value) { boolean_vars[FMI_BOOLEAN_USE_VIEWER_IDX]=value; }
     string fmi_xosc_path() { return string_vars[FMI_STRING_XOSC_PATH_IDX]; }
     void set_fmi_xosc_path(string value) { string_vars[FMI_STRING_XOSC_PATH_IDX]=value; }
+    string fmi_esmini_args() { return string_vars[FMI_STRING_ESMINI_ARGS_IDX]; }
+    void set_fmi_esmini_args(string value) { string_vars[FMI_STRING_ESMINI_ARGS_IDX]=value; }
 
     /* Protocol Buffer Accessors */
     bool get_fmi_traffic_update_in(osi3::TrafficUpdate& data);

--- a/OSMP_FMU/modelDescription.in.xml
+++ b/OSMP_FMU/modelDescription.in.xml
@@ -108,6 +108,9 @@
     <ScalarVariable name="xosc_path" valueReference="0" causality="parameter" variability="fixed">
       <String start=""/>
     </ScalarVariable>
+    <ScalarVariable name="esmini_args" valueReference="1" causality="parameter" variability="fixed">
+      <String start=""/>
+    </ScalarVariable>
     <ScalarVariable name="quit_flag" valueReference="12" causality="output" variability="discrete" initial="exact">
       <Integer start="0"/>
     </ScalarVariable>
@@ -121,7 +124,7 @@
       <Unknown index="11"/>
       <Unknown index="12"/>
       <Unknown index="13"/>
-      <Unknown index="16"/>
+      <Unknown index="17"/>
     </Outputs>
   </ModelStructure>
 </fmiModelDescription>

--- a/OSMP_FMU/modelDescription.in.xml
+++ b/OSMP_FMU/modelDescription.in.xml
@@ -111,9 +111,6 @@
     <ScalarVariable name="esmini_args" valueReference="1" causality="parameter" variability="fixed">
       <String start=""/>
     </ScalarVariable>
-    <ScalarVariable name="quit_flag" valueReference="12" causality="output" variability="discrete" initial="exact">
-      <Integer start="0"/>
-    </ScalarVariable>
   </ModelVariables>
   <ModelStructure>
     <Outputs>
@@ -124,7 +121,6 @@
       <Unknown index="11"/>
       <Unknown index="12"/>
       <Unknown index="13"/>
-      <Unknown index="17"/>
     </Outputs>
   </ModelStructure>
 </fmiModelDescription>

--- a/OSMP_FMU/modelDescription.in.xml
+++ b/OSMP_FMU/modelDescription.in.xml
@@ -108,6 +108,9 @@
     <ScalarVariable name="xosc_path" valueReference="0" causality="parameter" variability="fixed">
       <String start=""/>
     </ScalarVariable>
+    <ScalarVariable name="quit_flag" valueReference="12" causality="output" variability="discrete" initial="exact">
+      <Integer start="0"/>
+    </ScalarVariable>
   </ModelVariables>
   <ModelStructure>
     <Outputs>
@@ -118,6 +121,7 @@
       <Unknown index="11"/>
       <Unknown index="12"/>
       <Unknown index="13"/>
+      <Unknown index="16"/>
     </Outputs>
   </ModelStructure>
 </fmiModelDescription>

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,18 @@
 ## esmini release notes
 
+### 2025-06-13 Version 2.48.1
+
+Improvements and fixes:
+- Randomize cars for SUMO ctrl ([issue #706](https://github.com/esmini/esmini/issues/706))
+  - use cars and vans from available catalogs
+- Fix OpenDRIVE_traffic_signals.txt not found by renaming it to pure lowercase
+  - esmini (from v2.25.1) assumes prefix/country code to be lower case
+- Fix lost delayed triggers during ghost restart
+  - consider all condition events, both before and during restart phase
+- Improve CI smoke test runner
+  - speed up CI smoke tests by reducing watchdog sleep intervals
+  - print scenario execution time
+
 ### 2025-06-09 Version 2.48.0
 
 Code QA updates:


### PR DESCRIPTION
Pull request implemented the discussed points in https://github.com/esmini/esmini/issues/710

Implemented: 
 - ASSIGN_ROUTE
 - ACQUIRE_POSITION
 - FMU slave exit procedure according to FMI
   - Return `fmi2Discard`: https://github.com/heuerfin/esmini/blob/master/OSMP_FMU/esmini.cpp#L336
   - Report `fmi2Terminated` state https://github.com/heuerfin/esmini/blob/master/OSMP_FMU/esmini.cpp#L845
   - Tell co-simulation to end on first FMU exit `first_component` https://github.com/heuerfin/esmini/blob/master/OSMP_FMU/ExampleSystemStructure.ssd#L120
 - Arbitrary esmini arguments a FMU parameters

Bug Fixes:

- Memory access: https://github.com/esmini/esmini/blob/master/OSMP_FMU/esmini.h#L205 -> 1 buffer used for both OSI out messages, split into 2 buffers
- Issue regarding TrafficCommand content not reported due to multiple update calls (by https://github.com/esmini/esmini/blob/master/OSMP_FMU/esmini.cpp#L271 and https://github.com/esmini/esmini/blob/master/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp#L327)
- The TrafficCommand OSI timestamp had also an issue regarding the nano seconds
- TrafficCommand ActionHeader->Id Fix (https://github.com/esmini/esmini/blob/master/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSITrafficCommand.cpp#L101 the field of the lane change action is used instead of the speed actions)
