### PR TITLE
doc: fix type indices in documentation

### DIFF
--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -672,7 +672,7 @@ extern "C"
     /**
             Get the name of a named parameter
             @param index The index of the parameter, range [0:numberOfParameters-1]
-            @param Output parameter type 0=int, 1=double, 2=string (const char*), 3=bool, see OSCParameterDeclarations/ParameterType
+            @param Output parameter type 1=int, 2=double, 3=string (const char*), 4=bool, see OSCParameterDeclarations/ParameterType
             @return name if found, else 0
     */
     SE_DLL_API const char *SE_GetParameterName(int index, int *type);
@@ -686,7 +686,7 @@ extern "C"
     /**
             Get the name of a named variable
             @param index The index of the variable, range [0:numberOfVariables-1]
-            @param Output variable type 0=int, 1=double, 2=string (const char*), 3=bool, see OSCParameterDeclarations/ParameterType
+            @param Output variable type 1=int, 2=double, 3=string (const char*), 4=bool, see OSCParameterDeclarations/ParameterType
             @return name if found, else 0
     */
     SE_DLL_API const char *SE_GetVariableName(int index, int *type);


### PR DESCRIPTION
The `enum class ParameterType` defines a `PARAM_TYPE_NONE` entry as the first element.
As a result, all subsequent parameter types are assigned indices starting from 1.

Note: This indexing behavior is currently not covered by unit tests.


Reference: https://github.com/esmini/esmini/blob/3d07b60934cb0824a58cfe2bbafca3b36b0171a2/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCParameterDeclarations.hpp#L29-L36