### PR TITLE
Fix incorrect return type on GetCountourType

### DIFF
--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.hpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.hpp
@@ -1769,7 +1769,7 @@ namespace roadmanager
         {
             contourType_ = contourType;
         }
-        bool GetCountourType() const
+        ContourType GetCountourType() const
         {
             return contourType_;
         }


### PR DESCRIPTION
Hey Emil,

I recently upgraded my roadmanager fork to the latest release (I was nearly two years behind), and the compiler on the Unreal side of things complained about this return type, which indeed seems rather odd (not sure why it doesn't complain on the esmini side, there's not even a warning).

I'm truly out of the loop on that code so maybe it's intentional in which case you can totally discard that PR. But I thought it was worth mentioning in case it's indeed an error.

Once again, thank you for all your work! I recently added [two procedural-placement features](https://github.com/brifsttar/OpenDRIVE?tab=readme-ov-file#spawn-along-s) to our Unreal-OpenDRIVE plugin, making prop placement much easier, and all that is powered by roadmanager (and its incredible `MoveAlongS`).