### PR TITLE
Feature/osc validation integration

### DIFF
--- a/.github/actions/run_osc_validation/action.yml
+++ b/.github/actions/run_osc_validation/action.yml
@@ -8,8 +8,9 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: PMSFIT/osc-validation
-        ref: 44c6a2f
+        ref: 44c6a2f4c8363aebf8fcb8e9822fdcca677d51f6
         fetch-depth: 1
+        path: osc-validation
 
     - name: Set up Python venv
       shell: bash
@@ -22,6 +23,7 @@ runs:
         popd
 
     - name: Run osc-validation pytest suite
+      id: run_tests
       shell: bash
       run: |
         pushd osc-validation

--- a/.github/actions/run_osc_validation/action.yml
+++ b/.github/actions/run_osc_validation/action.yml
@@ -1,0 +1,49 @@
+name: "Run osc-validation"
+description: "Install osc-validation, run pytest suite, convert JUnit XML to HTML, and collect artifacts"
+runs:
+  using: "composite"
+  steps:
+
+    - name: Clone osc-validation
+      shell: bash
+      run: |
+        git clone --branch testing --single-branch https://github.com/PMSFIT/osc-validation.git
+
+    - name: Set up Python venv
+      shell: bash
+      run: |
+        pushd osc-validation
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip install -e .
+        pip install junit2html
+        popd
+
+    - name: Run osc-validation pytest suite
+      shell: bash
+      continue-on-error: true
+      run: |
+        pushd osc-validation
+        source .venv/bin/activate
+
+        SIM_BIN="$(pwd)/../bin/esmini"
+        echo "Using esmini binary: $SIM_BIN"
+
+        mkdir -p osc_validation_results
+
+        pytest validation/scenario/ \
+          --tool ESMini \
+          --toolpath "$SIM_BIN" \
+          -m trajectory \
+          -v \
+          --junitxml=osc_validation_results/junit.xml || true
+
+        cd osc_validation_results
+        junit2html junit.xml junit.html
+        popd
+
+    - name: Upload osc-validation artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: osc-validation
+        path: osc-validation/osc_validation_results

--- a/.github/actions/run_osc_validation/action.yml
+++ b/.github/actions/run_osc_validation/action.yml
@@ -4,10 +4,12 @@ runs:
   using: "composite"
   steps:
 
-    - name: Clone osc-validation
-      shell: bash
-      run: |
-        git clone --branch testing --single-branch https://github.com/PMSFIT/osc-validation.git
+    - name: Checkout osc-validation
+      uses: actions/checkout@v4
+      with:
+        repository: PMSFIT/osc-validation
+        ref: 44c6a2f
+        fetch-depth: 1
 
     - name: Set up Python venv
       shell: bash

--- a/.github/actions/run_osc_validation/action.yml
+++ b/.github/actions/run_osc_validation/action.yml
@@ -21,7 +21,6 @@ runs:
 
     - name: Run osc-validation pytest suite
       shell: bash
-      continue-on-error: true
       run: |
         pushd osc-validation
         source .venv/bin/activate
@@ -31,18 +30,24 @@ runs:
 
         mkdir -p osc_validation_results
 
+        set +e
         pytest validation/scenario/ \
           --tool ESMini \
           --toolpath "$SIM_BIN" \
           -m trajectory \
           -v \
-          --junitxml=osc_validation_results/junit.xml || true
+          --basetemp osc_validation_results \
+          --junitxml osc_validation_results/junit.xml || true
+        pytest_exit_code=$?
 
         cd osc_validation_results
         junit2html junit.xml junit.html
+
         popd
+        exit $pytest_exit_code
 
     - name: Upload osc-validation artifacts
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: osc-validation

--- a/.github/actions/run_osc_validation/action.yml
+++ b/.github/actions/run_osc_validation/action.yml
@@ -35,16 +35,16 @@ runs:
           --tool ESMini \
           --toolpath "$SIM_BIN" \
           -m trajectory \
-          -v \
           --basetemp osc_validation_results \
-          --junitxml osc_validation_results/junit.xml || true
-        pytest_exit_code=$?
+          --junitxml osc_validation_results/junit.xml
+        code=$?
+        echo "exitcode=$code" >> $GITHUB_OUTPUT
+        echo "osc-validation finished with exit code $code"
 
         cd osc_validation_results
         junit2html junit.xml junit.html
 
         popd
-        exit $pytest_exit_code
 
     - name: Upload osc-validation artifacts
       if: always()
@@ -52,3 +52,12 @@ runs:
       with:
         name: osc-validation
         path: osc-validation/osc_validation_results
+
+    - name: Fail if tests failed
+      if: always()
+      shell: bash
+      run: |
+        if [ "${{ steps.run_tests.outputs.exitcode }}" != "0" ]; then
+          echo "osc-validation failed"
+          exit 1
+        fi

--- a/.github/actions/run_osc_validation/action.yml
+++ b/.github/actions/run_osc_validation/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: PMSFIT/osc-validation
-        ref: 44c6a2f4c8363aebf8fcb8e9822fdcca677d51f6
+        ref: 0a3075d4f1c4b663c3e7831b415cf60d3397f51a
         fetch-depth: 1
         path: osc-validation
 

--- a/.github/actions/run_osc_validation/action.yml
+++ b/.github/actions/run_osc_validation/action.yml
@@ -18,7 +18,7 @@ runs:
         pushd osc-validation
         python3 -m venv .venv
         source .venv/bin/activate
-        pip install -e .
+        pip install -e . "numpy<2.0"
         popd
 
     - name: Run osc-validation
@@ -37,6 +37,7 @@ runs:
         osc-validate \
           --tool ESMini \
           --toolpath "$SIM_BIN" \
+          --test-profile "$GITHUB_ACTION_PATH/test_profile.toml" \
           --html osc_validation_results/report.html
         code=$?
         echo "exitcode=$code" >> $GITHUB_OUTPUT

--- a/.github/actions/run_osc_validation/action.yml
+++ b/.github/actions/run_osc_validation/action.yml
@@ -8,7 +8,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: PMSFIT/osc-validation
-        ref: b015e68b74f1d9c529f9dbf9964e3116a85a0f1b
+        ref: v0.1.0
         fetch-depth: 1
         path: osc-validation
 
@@ -21,7 +21,7 @@ runs:
         pip install -e .
         popd
 
-    - name: Run osc-validation pytest suite
+    - name: Run osc-validation
       id: run_tests
       shell: bash
       run: |
@@ -34,14 +34,10 @@ runs:
         mkdir -p osc_validation_results
 
         set +e
-        pytest \
-          validation/scenario/trajectories \
-          validation/scenario/triggers \
+        osc-validate \
           --tool ESMini \
           --toolpath "$SIM_BIN" \
-          --basetemp osc_validation_results \
-          --html osc_validation_results/report.html \
-          --self-contained-html
+          --html osc_validation_results/report.html
         code=$?
         echo "exitcode=$code" >> $GITHUB_OUTPUT
         echo "osc-validation finished with exit code $code"
@@ -60,6 +56,6 @@ runs:
       shell: bash
       run: |
         if [ "${{ steps.run_tests.outputs.exitcode }}" != "0" ]; then
-          echo "osc-vali idation failed"
+          echo "osc-validation failed"
           exit 1
         fi

--- a/.github/actions/run_osc_validation/action.yml
+++ b/.github/actions/run_osc_validation/action.yml
@@ -1,5 +1,5 @@
 name: "Run osc-validation"
-description: "Install osc-validation, run pytest suite, convert JUnit XML to HTML, and collect artifacts"
+description: "Install osc-validation, run pytest suite with HTML report, and collect artifacts"
 runs:
   using: "composite"
   steps:
@@ -8,7 +8,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: PMSFIT/osc-validation
-        ref: 0a3075d4f1c4b663c3e7831b415cf60d3397f51a
+        ref: b015e68b74f1d9c529f9dbf9964e3116a85a0f1b
         fetch-depth: 1
         path: osc-validation
 
@@ -19,7 +19,6 @@ runs:
         python3 -m venv .venv
         source .venv/bin/activate
         pip install -e .
-        pip install junit2html
         popd
 
     - name: Run osc-validation pytest suite
@@ -35,18 +34,17 @@ runs:
         mkdir -p osc_validation_results
 
         set +e
-        pytest validation/scenario/ \
+        pytest \
+          validation/scenario/trajectories \
+          validation/scenario/triggers \
           --tool ESMini \
           --toolpath "$SIM_BIN" \
-          -m trajectory \
           --basetemp osc_validation_results \
-          --junitxml osc_validation_results/junit.xml
+          --html osc_validation_results/report.html \
+          --self-contained-html
         code=$?
         echo "exitcode=$code" >> $GITHUB_OUTPUT
         echo "osc-validation finished with exit code $code"
-
-        cd osc_validation_results
-        junit2html junit.xml junit.html
 
         popd
 
@@ -62,6 +60,6 @@ runs:
       shell: bash
       run: |
         if [ "${{ steps.run_tests.outputs.exitcode }}" != "0" ]; then
-          echo "osc-validation failed"
+          echo "osc-vali idation failed"
           exit 1
         fi

--- a/.github/actions/run_osc_validation/test_profile.toml
+++ b/.github/actions/run_osc_validation/test_profile.toml
@@ -1,3 +1,15 @@
 [[xfail]]
 test = "scenario/trajectories/val_interpolation.py::test_timed_polyline_trajectory_interpolation[constant_acceleration_from_initial_speed-*]"
 reason = "ESMini does not currently support timed polyline constant-acceleration interpolation."
+
+[[xfail]]
+test = "scenario/trajectories/val_follow_trajectory_future_time_reference.py::test_follow_trajectory_future_time_reference_continues_init_speed_until_first_vertex"
+reason = "ESMini does not currently implement this OpenSCENARIO FollowTrajectoryAction special case (OpenSCENARIO Specification section 6.9.2)."
+
+[[xfail]]
+test = "scenario/trajectories/val_follow_trajectory_teleport.py::test_follow_trajectory_position_mode_teleports_to_current_trajectory_time[exact_trajectory_point-2.0]"
+reason = "ESMini does not currently implement this OpenSCENARIO FollowTrajectoryAction special case (OpenSCENARIO Specification section 6.9.3)."
+
+[[xfail]]
+test = "scenario/trajectories/val_follow_trajectory_teleport.py::test_follow_trajectory_position_mode_teleports_to_current_trajectory_time[between_trajectory_points-1.0]"
+reason = "ESMini does not currently implement this OpenSCENARIO FollowTrajectoryAction special case (OpenSCENARIO Specification section 6.9.3)."

--- a/.github/actions/run_osc_validation/test_profile.toml
+++ b/.github/actions/run_osc_validation/test_profile.toml
@@ -1,0 +1,3 @@
+[[xfail]]
+test = "scenario/trajectories/val_interpolation.py::test_timed_polyline_trajectory_interpolation[constant_acceleration_from_initial_speed-*]"
+reason = "ESMini does not currently support timed polyline constant-acceleration interpolation."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         if: runner.os == 'Linux' && matrix.configuration == 'Release'
         shell: bash
         run: |
-          git clone --branch feature/always-stdout-esmini-log --single-branch https://github.com/PMSFIT/osc-validation.git
+          git clone --branch testing --single-branch https://github.com/PMSFIT/osc-validation.git
           pushd osc-validation
           python3 -m venv .venv
           source .venv/bin/activate
@@ -162,7 +162,7 @@ jobs:
           pytest validation/scenario/ \
             --tool ESMini \
             --toolpath "$SIM_BIN" \
-            -k "test_trajectory" \
+            -m trajectory \
             -v
           popd
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,44 +139,9 @@ jobs:
       - name: CMake Build
         run: cmake --build build --config ${{ matrix.configuration }} --target install -j 2
 
-      - name: Install osc-validation
+      - name: Run osc-validation
         if: runner.os == 'Linux' && matrix.configuration == 'Release'
-        shell: bash
-        run: |
-          git clone --branch testing --single-branch https://github.com/PMSFIT/osc-validation.git
-          pushd osc-validation
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install -e .
-          pip install junit2html
-          popd
-
-      - name: Run osc-validation pytest suite
-        if: runner.os == 'Linux' && matrix.configuration == 'Release'
-        continue-on-error: true
-        shell: bash
-        run: |
-          pushd osc-validation
-          source .venv/bin/activate
-          SIM_BIN="$(pwd)/../bin/esmini"
-          echo "Using esmini binary: $SIM_BIN"
-          mkdir -p osc_validation_results
-          pytest validation/scenario/ \
-            --tool ESMini \
-            --toolpath "$SIM_BIN" \
-            -m trajectory \
-            -v \
-            --junitxml=osc_validation_results/junit.xml
-          cd osc_validation_results
-          junit2html junit.xml junit.html
-          popd
-
-      - name: Upload osc-validation artifacts
-        if: runner.os == 'Linux' && matrix.configuration == 'Release'
-        uses: actions/upload-artifact@v4
-        with:
-          name: osc-validation_${{ runner.os }}_${{ matrix.configuration }}
-          path: osc-validation/osc_validation_results
+        uses: ./.github/actions/run_osc_validation
 
       - name: Compile minimal C example
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
           python3 -m venv .venv
           source .venv/bin/activate
           pip install -e .
+          pip install junit2html
           popd
 
       - name: Run osc-validation pytest suite
@@ -159,12 +160,23 @@ jobs:
           source .venv/bin/activate
           SIM_BIN="$(pwd)/../bin/esmini"
           echo "Using esmini binary: $SIM_BIN"
+          mkdir -p osc_validation_results
           pytest validation/scenario/ \
             --tool ESMini \
             --toolpath "$SIM_BIN" \
             -m trajectory \
-            -v
+            -v \
+            --junitxml=osc_validation_results/junit.xml
+          cd osc_validation_results
+          junit2html junit.xml junit.html
           popd
+
+      - name: Upload osc-validation artifacts
+        if: runner.os == 'Linux' && matrix.configuration == 'Release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: osc-validation_${{ runner.os }}_${{ matrix.configuration }}
+          path: osc-validation/osc_validation_results
 
       - name: Compile minimal C example
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,33 @@ jobs:
       - name: CMake Build
         run: cmake --build build --config ${{ matrix.configuration }} --target install -j 2
 
+      - name: Install osc-validation
+        if: runner.os == 'Linux' && matrix.configuration == 'Release'
+        shell: bash
+        run: |
+          git clone --branch feature/always-stdout-esmini-log --single-branch https://github.com/PMSFIT/osc-validation.git
+          pushd osc-validation
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install -e .
+          popd
+
+      - name: Run osc-validation pytest suite
+        if: runner.os == 'Linux' && matrix.configuration == 'Release'
+        continue-on-error: true
+        shell: bash
+        run: |
+          pushd osc-validation
+          source .venv/bin/activate
+          SIM_BIN="$(pwd)/../bin/esmini"
+          echo "Using esmini binary: $SIM_BIN"
+          pytest validation/scenario/ \
+            --tool ESMini \
+            --toolpath "$SIM_BIN" \
+            -k "test_trajectory" \
+            -v
+          popd
+
       - name: Compile minimal C example
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,10 +139,6 @@ jobs:
       - name: CMake Build
         run: cmake --build build --config ${{ matrix.configuration }} --target install -j 2
 
-      - name: Run osc-validation
-        if: runner.os == 'Linux' && matrix.configuration == 'Release'
-        uses: ./.github/actions/run_osc_validation
-
       - name: Compile minimal C example
         if: runner.os == 'Linux'
         run: |
@@ -207,6 +203,25 @@ jobs:
       - name: Debugging with tmate
         if: ${{ failure() && env.USE_TMATE == 'true' }}
         uses: mxschmitt/action-tmate@v3
+
+  osc-validation:
+    needs: [test]
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v4.1.7
+        with:
+          name: esmini-bin_Linux
+
+      - name: Extract Ubuntu release binary artifact
+        run: |
+          unzip -q esmini-bin_Linux.zip
+          ln -s esmini/bin bin
+
+      - name: Run osc-validation
+        uses: ./.github/actions/run_osc_validation
 
   test-no-external-modules:
     needs: [lint]

--- a/.github/workflows/memoryleak.yml
+++ b/.github/workflows/memoryleak.yml
@@ -1,11 +1,6 @@
 name: MemoryLeak
 
 on:
-  schedule:
-    # This will run the memory leak check job Nightly at 1AM every day for the dev branch
-    # * is a special character in YAML so you have to quote this string
-    - cron: '0 1 * * *'
-
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -1,11 +1,6 @@
 name: Sanitize
 
 on:
-  schedule:
-    # This will run the sanitize job Nightly at 3AM every day for the dev branch
-    # * is a special character in YAML so you have to quote this string
-    - cron: '0 3 * * *'
-
   workflow_dispatch:
 
 jobs:

--- a/OSMP_FMU/CMakeLists.txt
+++ b/OSMP_FMU/CMakeLists.txt
@@ -10,9 +10,20 @@ execute_process(
     ERROR_QUIET)
 
 message("Version: " ${VERSION})
+if(NOT VERSION OR VERSION STREQUAL "")
+    # git describe returned nothing (fork or shallow clone)
+    set(VERSION "v0.0.0")
+endif()
 
 # Strip prefix "v" and any trailing line break
-string(SUBSTRING "${VERSION}" 1 -1 VERSION )
+string(LENGTH "${VERSION}" _vlen)
+if(_vlen GREATER 1)
+    string(SUBSTRING "${VERSION}" 1 -1 VERSION)
+else()
+    # Fallback: remove leading v manually or leave unchanged
+    set(VERSION "0.0.0")
+endif()
+
 string(STRIP "${VERSION}" VERSION)
 
 set(OSIVERSION "3.5.0")

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -47,7 +47,7 @@ export SMOKE_TEST_FOLDER=${workingDir}/test
 export ESMINI_CS_WRAPPER_FOLDER=${workingDir}/test/CSharpWrappers/build/${build_type}
 export ESMINI_CS_WRAPPER_BINARY=libesmini_cs_wrapper_test
 
-if [[ "$OSTYPE" == "msys" ]]; then
+if [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
     export PATH=${PATH}":${workingDir}/build/EnvironmentSimulator/Libraries/esminiLib/${build_type}:${workingDir}/build/EnvironmentSimulator/Libraries/esminiRMLib/${build_type}"
     export EXE_FOLDER="./$build_type"
     export PYTHON="python"
@@ -66,7 +66,7 @@ else
     echo "Unsupported OS: " $OSTYPE
 fi
 
-if [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "linux-gnu"* ]]; then
+if [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "linux-gnu"* ]]; then
 
     cd $UNIT_TEST_FOLDER
 
@@ -120,7 +120,7 @@ if [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "linux-gnu"* ]]; then
     fi
 fi
 
-if [[ "$OSTYPE" == "msys" ]] && [[ "$add_wrapper_test" == true ]]; then
+if [[ ("$OSTYPE" == "msys" || "$OSTYPE" == "cygwin") && "$add_wrapper_test" == true ]]; then
     echo $'\n'Run C# esminiLib wrapper test:
     cd ${workingDir}/bin
     if ! ${ESMINI_CS_WRAPPER_FOLDER}/${ESMINI_CS_WRAPPER_BINARY}; then


### PR DESCRIPTION
This is a draft/proposal to include [osc-validation](https://github.com/PMSFIT/osc-validation) in the CI pipeline of ESMini.

Coming from the [European Synergies project](https://synergies-ccam.eu/), we developed an OpenSCENARIO engine validation tool called `osc-validation` (open source). The goal is to detect behavioral differences between scenario engines based on their OSI output but also potential deviations from the OSC standard (for OSC definitions that are unambiguous). Another long-term goal is to identify underspecified or ambiguous parts of the OSC standard.

`osc-validation` is temporarily hosted at https://github.com/PMSFIT/osc-validation. It's soon going to be part of the OpenMSL project.

The only integrated test currently verifies that the vehicle trajectories in the OSI output deviate only marginally from the input data, which ESMini is expected to satisfy.
Though, with the current state of the test case, ESMini would fail because of an integrated ASAM OSI Quality Checker (https://github.com/OpenSimulationInterface/qc-osi-trace) which checks the tool output for compliance with [OSI 3.7.0 rules](https://github.com/OpenSimulationInterface/qc-osi-trace/blob/main/qc_ositrace/checks/osirules/rulesyml/osi_3_7_0.yml) which are based on the `/rules` sections in the proto definitions. The checker result shows that there are some problems with unique assignment of IDs in ESMini's OSI output (different object types have overlapping ID space).

If you are interested in integrating this into ESMini's pipeline, I would ask you to review the CI setup and check out `osc-validation`.

I had to upgrade from Python 3.8 to 3.10 for compatibility reasons. But this should be fine since Python 3.8 already reached its EOL about a year ago. We could even go higher since 3.10 is already close to its EOL timeline.

*Sidenote:*
Also, I noticed that there are some issues with the current pipeline setup when running it in a fork (due to missing tags etc.); see the changes in OSMP_FMU/CMakeLists.txt. This should be removed before ever merging this PR. This is just there so that the pipeline runs properly in my fork.

@jdsika