### PR TITLE
Copy OSI version from ground truth to sensor view

### DIFF
--- a/OSMP_FMU/esmini.cpp
+++ b/OSMP_FMU/esmini.cpp
@@ -316,6 +316,7 @@ fmi2Status EsminiOsiSource::doCalc(fmi2Real currentCommunicationPoint, fmi2Real 
     osi3::SensorView currentOut;
     currentOut.Clear();
     currentOut.mutable_sensor_id()->set_value(0);
+    currentOut.mutable_version()->CopyFrom(se_osi_ground_truth->version());
     currentOut.mutable_host_vehicle_id()->set_value(se_osi_ground_truth->host_vehicle_id().value());
     double const time = currentCommunicationPoint + communicationStepSize;
     currentOut.mutable_timestamp()->set_seconds((long long int)floor(time));


### PR DESCRIPTION
The OSI version is a mandatory field in all top-level messages but it was missing from the SensorView message created by the OSMP FMU. Now it is copied from the GroundTruth.