### PR TITLE
Add SE_ObjectCanChangeLanes() to check underlying road for allowed lane changes

### DIFF
--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -1656,14 +1656,14 @@ extern "C"
 
         if (has_left && lsec != nullptr)
         {
-            roadmanager::Lane *        markLane = (lane_id > 0) ? lsec->GetLaneById(lane_id) : lsec->GetLaneById(lane_id + 1);
+            roadmanager::Lane         *markLane = (lane_id > 0) ? lsec->GetLaneById(lane_id) : lsec->GetLaneById(lane_id + 1);
             roadmanager::LaneRoadMark *rm       = GetRoadMarkAtS(markLane, lsec, s);
             can_left                            = RoadMarkAllowsLaneChange(rm, 1);
         }
 
         if (has_right && lsec != nullptr)
         {
-            roadmanager::Lane *        markLane = (lane_id < 0) ? lsec->GetLaneById(lane_id) : lsec->GetLaneById(lane_id - 1);
+            roadmanager::Lane         *markLane = (lane_id < 0) ? lsec->GetLaneById(lane_id) : lsec->GetLaneById(lane_id - 1);
             roadmanager::LaneRoadMark *rm       = GetRoadMarkAtS(markLane, lsec, s);
             can_right                           = RoadMarkAllowsLaneChange(rm, -1);
         }

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -1128,6 +1128,21 @@ extern "C"
     SE_DLL_API int SE_GetObjectInLaneType(int object_id);
 
     /**
+            Check if lane change is possible for specified object based on number of drivable lanes
+            and road mark (line type) restrictions. A lane change direction is only reported as
+            possible when a neighboring driving lane exists AND the road mark on the boundary
+            allows crossing in that direction (e.g. broken line or laneChange="both"/"increase"/"decrease").
+            If the object is not currently in a driving lane, returns 0 (no lane change possible).
+            @param object_id Id of the object
+            @return 0 = no lane change possible (including when object is not in a driving lane),
+                    1 = lane change to the left is possible,
+                    2 = lane change to the right is possible,
+                    3 = lane change to both left and right is possible,
+                   -1 = error (e.g. invalid object or missing road)
+    */
+    SE_DLL_API int SE_ObjectCanChangeLanes(int object_id);
+
+    /**
             Get the overrideActionStatus of specified object
             @param objectId Id of the object
             @param list Pointer/reference to a SE_OverrideActionList struct to be filled in

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -1144,11 +1144,11 @@ extern "C"
 
     /**
             Get the overrideActionStatus of specified object
-            @param objectId Id of the object
+            @param object_id Id of the object
             @param list Pointer/reference to a SE_OverrideActionList struct to be filled in
             @return 0 if successful, -1 if not
     */
-    SE_DLL_API int SE_GetOverrideActionStatus(int objectId, SE_OverrideActionList *list);
+    SE_DLL_API int SE_GetOverrideActionStatus(int object_id, SE_OverrideActionList *list);
 
     /**
             Get the type name of the specifed vehicle-, pedestrian- or misc object
@@ -1180,7 +1180,7 @@ extern "C"
 
     /**
             Get ID of the ghost associated with given object
-            @param object_id Id of the ghost object
+            @param object_id Id of the object to which the ghost is attached
             @return ghost object ID, -1 if ghost does not exist for given object
     */
     SE_DLL_API int SE_GetObjectGhostId(int object_id);
@@ -1624,7 +1624,7 @@ extern "C"
 
     /**
             The SE_GetOSILaneBoundaryIds function the global ids for left, far left, right and far right lane boundaries
-            @param object_id Handle to the object to which the sensor should be attached
+            @param object_id Id of the object
             @param ids Reference to a struct which will be filled with the Ids
     */
     SE_DLL_API void SE_GetOSILaneBoundaryIds(int object_id, SE_LaneBoundaryId *ids);


### PR DESCRIPTION
I added a new function `SE_ObjectCanChangeLanes()` (+ helpers) to esminiLib.hpp/.cpp.

The method can be used to check if lane changes for a given object are possible.  
I tested it on Carla's Town04, seems to work fine.

**However, I am not sure how the internal handling of `LaneChangeAction`s works, maybe there is a simpler approach?**