### PR TITLE
Clear unknown_args_ in SE_Options::Reset

### DIFF
--- a/EnvironmentSimulator/Modules/CommonMini/CommonMini.cpp
+++ b/EnvironmentSimulator/Modules/CommonMini/CommonMini.cpp
@@ -2789,6 +2789,7 @@ void SE_Options::Reset()
         }
     }
     originalArgs_.clear();
+    unknown_args_.clear();
 }
 
 int SE_WritePPM(const char* filename, int width, int height, const unsigned char* data, int pixelSize, int pixelFormat, bool upsidedown)


### PR DESCRIPTION
### Summary
`SE_Options::Reset()` did not clear unknown_args_. Stale entries from a previous ParseArgs cycle survived the reset, causing HasUnknownArgs() to return true and PrintUnknownArgs() to print stale arguments on subsequent runs even when the new args are clean.

### Fix
One-line addition in `SE_Options::Reset()`

### Impact
Affects any process that re-initializes esmini in the same address space (Python bindings, embedded library users, `SE_Init → SE_Close → SE_Init`). `SE_Close` does not call` Options::Reset()`; it is invoked at the start of the next `SE_Init` (playerbase.cpp:126), so the stale state is directly observable across re-initialization.

Closes #806