### PR TITLE
Guard against null Route::GetWaypoint() in route-relative motion

### DIFF
--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -12127,7 +12127,15 @@ int Position::SetRouteLanePosition(Route* route, double path_s, int lane_id, dou
     int dir = 1;
     if (SE_Env::Inst().GetOptions().GetOptionSet("align_routepositions"))
     {
-        dir = route->GetWaypoint()->GetRouteWaypointDir();
+        const Position* wp = route->GetWaypoint();
+        if (wp != nullptr)
+        {
+            dir = wp->GetRouteWaypointDir();
+        }
+        else
+        {
+            LOG_ERROR("SetRouteLanePosition: failed to get current waypoint, using default direction");
+        }
     }
 
     SetLanePos(route->GetTrackId(), SIGN(dir) * lane_id, route->GetTrackS(), SIGN(dir) * lane_offset);
@@ -12143,7 +12151,15 @@ int Position::SetRouteRoadPosition(Route* route, double path_s, double t)
     int dir = 1;
     if (SE_Env::Inst().GetOptions().GetOptionSet("align_routepositions"))
     {
-        dir = route->GetWaypoint()->GetRouteWaypointDir();
+        const Position* wp = route->GetWaypoint();
+        if (wp != nullptr)
+        {
+            dir = wp->GetRouteWaypointDir();
+        }
+        else
+        {
+            LOG_ERROR("SetRouteRoadPosition: failed to get current waypoint, using default direction");
+        }
     }
 
     SetTrackPos(route->GetTrackId(), route->GetTrackS(), SIGN(dir) * t);
@@ -14730,7 +14746,13 @@ Position::ReturnCode Route::MovePathDS(double ds, double* remaining_dist, bool u
     }
 
     // Consider route direction
-    ds *= GetWaypoint()->GetRouteWaypointDir();
+    const Position* wp = GetWaypoint();
+    if (wp == nullptr)
+    {
+        LOG_ERROR("MovePathDS: failed to get current waypoint");
+        return Position::ReturnCode::ERROR_GENERIC;
+    }
+    ds *= wp->GetRouteWaypointDir();
     // printf("moving along path by ds = %.2f (route dir %d), from road %d s %.2f\n", ds, GetWaypoint()->GetRouteWaypointDir(),
     // currentPos_.GetTrackId(), currentPos_.GetS());
 
@@ -14754,11 +14776,21 @@ Position::ReturnCode Route::SetPathS(double s, double* remaining_dist, bool upda
 
         if (update_state)
         {
-            LOG_INFO("{}{} moved out of route at roadId={}, s={:.2f} (SetPathS())",
-                     getObjName().empty() ? "Position " : "Entity ",
-                     getObjName().empty() ? "" : getObjName(),
-                     GetWaypoint(waypoint_idx_)->GetTrackId(),
-                     local_s);
+            const Position* wp = GetWaypoint(waypoint_idx_);
+            if (wp != nullptr)
+            {
+                LOG_INFO("{}{} moved out of route at roadId={}, s={:.2f} (SetPathS())",
+                         getObjName().empty() ? "Position " : "Entity ",
+                         getObjName().empty() ? "" : getObjName(),
+                         wp->GetTrackId(),
+                         local_s);
+            }
+            else
+            {
+                LOG_INFO("{}{} moved out of route (no valid waypoint) (SetPathS())",
+                         getObjName().empty() ? "Position " : "Entity ",
+                         getObjName().empty() ? "" : getObjName());
+            }
             on_route_ = false;
         }
 
@@ -14771,9 +14803,9 @@ Position::ReturnCode Route::SetPathS(double s, double* remaining_dist, bool upda
     if (minimal_waypoints_.size() == 0)
     {
         path_s_       = 0.0;
-        waypoint_idx_ = 0;
-        currentPos_.SetTrackPos(GetWaypoint(waypoint_idx_)->GetTrackId(), 0.0, 0.0);
-        return Position::ReturnCode::OK;
+        waypoint_idx_ = IDX_UNDEFINED;
+        LOG_ERROR("SetPathS called on route with no waypoints");
+        return Position::ReturnCode::ERROR_GENERIC;
     }
 
     const Position* wp = nullptr;

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
@@ -306,14 +306,6 @@ AssignRouteAction::~AssignRouteAction()
 void AssignRouteAction::Start(double simTime)
 {
     route_->setObjName(object_->GetName());
-
-    if (!route_->IsValid())
-    {
-        LOG_WARN("AssignRouteAction: Route {} is invalid, skipping route assignment for {}", route_->getName(), object_->GetName());
-        OSCAction::Start(simTime);
-        return;
-    }
-
     object_->pos_.SetRoute(route_);
     object_->dirty_.SetBits(Object::DirtyBit::ROUTE);
 
@@ -691,15 +683,7 @@ void AcquirePositionAction::Start(double simTime)
     start_wp.SetModeBits(roadmanager::Position::PosModeType::INIT, roadmanager::Position::PosMode::H_REL | roadmanager::Position::PosMode::H_SET);
     route_->AddWaypoint(start_wp);
     route_->AddWaypoint(target_position_);
-
     route_->CheckValid();
-
-    if (!route_->IsValid())
-    {
-        LOG_WARN("AcquirePositionAction: Route is invalid, skipping route assignment for {}", object_->GetName());
-        OSCAction::Start(simTime);
-        return;
-    }
 
     object_->pos_.SetRoute(route_);
     object_->dirty_.SetBits(Object::DirtyBit::ROUTE);

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCPrivateAction.cpp
@@ -306,6 +306,14 @@ AssignRouteAction::~AssignRouteAction()
 void AssignRouteAction::Start(double simTime)
 {
     route_->setObjName(object_->GetName());
+
+    if (!route_->IsValid())
+    {
+        LOG_WARN("AssignRouteAction: Route {} is invalid, skipping route assignment for {}", route_->getName(), object_->GetName());
+        OSCAction::Start(simTime);
+        return;
+    }
+
     object_->pos_.SetRoute(route_);
     object_->dirty_.SetBits(Object::DirtyBit::ROUTE);
 
@@ -683,6 +691,15 @@ void AcquirePositionAction::Start(double simTime)
     start_wp.SetModeBits(roadmanager::Position::PosModeType::INIT, roadmanager::Position::PosMode::H_REL | roadmanager::Position::PosMode::H_SET);
     route_->AddWaypoint(start_wp);
     route_->AddWaypoint(target_position_);
+
+    route_->CheckValid();
+
+    if (!route_->IsValid())
+    {
+        LOG_WARN("AcquirePositionAction: Route is invalid, skipping route assignment for {}", object_->GetName());
+        OSCAction::Start(simTime);
+        return;
+    }
 
     object_->pos_.SetRoute(route_);
     object_->dirty_.SetBits(Object::DirtyBit::ROUTE);


### PR DESCRIPTION
## Summary

`Route::GetWaypoint()` returns `nullptr` when the route has no minimal waypoints or when `waypoint_idx_` is `IDX_UNDEFINED` (e.g. after the entity is reported off-route, or when `AcquirePositionAction`'s target waypoint cannot be resolved). Several call sites dereferenced the result unconditionally and could segfault mid-simulation.

## Changes

- `Position::SetRouteLanePosition` / `SetRouteRoadPosition` — log error and fall back to default direction when waypoint is null (only triggered with `--align_routepositions`).
- `Route::MovePathDS` — return `ERROR_GENERIC` instead of dereferencing.
- `Route::SetPathS` — handle null waypoint in the "moved out of route" log, and return `ERROR_GENERIC` instead of touching waypoint 0 when `minimal_waypoints_` is empty.
- `AssignRouteAction::Start` / `AcquirePositionAction::Start` — skip route assignment with `LOG_WARN` when the constructed route is invalid, rather than installing it on the entity (which would defer the crash to the next route-motion call).

## Notes / caveats

- The vulnerable code paths are present in the source, but I was not able to deterministically reproduce a segfault using only the bundled scenarios. The crash was originally observed in a customer scenario with a different road network where `waypoint_idx_` becomes `IDX_UNDEFINED` while subsequent route-relative motion triggers the segfault.