### PR TITLE
Add Object::TimeToCollision and SE_GetTimeToCollision API

### DIFF
--- a/EnvironmentSimulator/Libraries/esminiLib/ESMiniWrapper.cs
+++ b/EnvironmentSimulator/Libraries/esminiLib/ESMiniWrapper.cs
@@ -1675,6 +1675,19 @@ namespace ESMini
         public static extern int SE_SimpleGetDistanceToObject(int object_a_id, int object_b_id, SE_RelativeDistanceType dist_type, double tracking_limit, out double distance, out double timestamp);
 
         /// <summary>
+        /// Compute time to collision (TTC) between two objects, mirroring OpenSCENARIO TimeToCollisionCondition.
+        /// </summary>
+        /// <param name="object_a_id">Id of the object from which to measure</param>
+        /// <param name="object_b_id">Id of the target object</param>
+        /// <param name="cs">Coordinate system, see roadmanager::CoordinateSystem</param>
+        /// <param name="dist_type">Enum specifying what distance to measure</param>
+        /// <param name="free_space">Measure distance between bounding boxes (true) or between ref points (false)</param>
+        /// <param name="ttc">Output: time to collision in seconds, or -1.0 when undefined</param>
+        /// <returns>0 on success, -1 on failure (invalid object id, null ttc pointer)</returns>
+        [DllImport(NativeLibrary, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int SE_GetTimeToCollision(int object_a_id, int object_b_id, int cs, SE_RelativeDistanceType dist_type, [MarshalAs(UnmanagedType.I1)] bool free_space, out double ttc);
+
+        /// <summary>
         /// Create an ideal object sensor and attach to specified vehicle
         /// </summary>
         /// <param name="object_id">Handle to the object to which the sensor should be attached</param>

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -2405,6 +2405,32 @@ extern "C"
         return obj_found;
     }
 
+    SE_DLL_API int SE_GetTimeToCollision(int object_a_id, int object_b_id, int cs, SE_RelativeDistanceType dist_type, bool free_space, double *ttc)
+    {
+        if (ttc == nullptr)
+        {
+            return -1;
+        }
+
+        Object *obj_a = nullptr;
+        if (getObjectById(object_a_id, obj_a) == -1)
+        {
+            return -1;
+        }
+
+        Object *obj_b = nullptr;
+        if (getObjectById(object_b_id, obj_b) == -1)
+        {
+            return -1;
+        }
+
+        return obj_a->TimeToCollision(obj_b,
+                                      static_cast<roadmanager::CoordinateSystem>(cs),
+                                      static_cast<roadmanager::RelativeDistanceType>(dist_type),
+                                      free_space,
+                                      *ttc);
+    }
+
     void objCallbackFn(scenarioengine::Object *obj, void *my_data)
     {
         for (size_t i = 0; i < objCallback.size(); i++)

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -1419,6 +1419,20 @@ extern "C"
                                                 double                 *timestamp);
 
     /**
+            Compute time to collision (TTC) between two objects, mirroring the math used
+            by OpenSCENARIO TimeToCollisionCondition.
+            @param object_a_id Id of the object from which to measure
+            @param object_b_id Id of the target object
+            @param cs Coordinate system, see roadmanager::CoordinateSystem
+            @param dist_type Enum specifying what distance to measure
+            @param free_space Measure distance between bounding boxes (true) or between ref points (false)
+            @param ttc Output: time to collision in seconds, or -1.0 when undefined
+                       (target behind, moving apart, or zero relative speed)
+            @return 0 on success, -1 on failure (invalid object id, null ttc pointer)
+    */
+    SE_DLL_API int SE_GetTimeToCollision(int object_a_id, int object_b_id, int cs, SE_RelativeDistanceType dist_type, bool free_space, double *ttc);
+
+    /**
             Create an ideal object sensor and attach to specified vehicle
             @param object_id Handle to the object to which the sensor should be attached
             @param x Position x coordinate of the sensor in vehicle local coordinates

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCCondition.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCCondition.cpp
@@ -812,74 +812,40 @@ bool TrigByTimeToCollision::CheckCondition(double sim_time)
             {
                 continue;
             }
-            retVal = trigObj->Distance(object_, cs_, relDistType_, freespace_, rel_dist);
+            trigObj->TimeToCollision(object_, cs_, relDistType_, freespace_, ttc_);
         }
         else
         {
             roadmanager::Position* pos = position_->GetRMPos();
             retVal                     = trigObj->Distance(pos->GetX(), pos->GetY(), cs_, relDistType_, freespace_, rel_dist);
-        }
 
-        if (retVal != 0)
-        {
-            rel_dist = LARGE_NUMBER;
-        }
-
-        if (object_)
-        {
-            if (fabs(object_->pos_.GetVelX()) < SMALL_NUMBER && fabs(object_->pos_.GetVelY()) < SMALL_NUMBER)
+            if (retVal != 0)
             {
-                // object standing still, consider only speed of triggering entity
-                rel_speed = trigObj->GetSpeed();
+                rel_dist = LARGE_NUMBER;
             }
-            else
-            {
-                double rel_vel[2] = {0.0, 0.0};
-                // Calculate relative speed of triggering entity along object's velocity direction
-                double proj_speed = ProjectPointOnVector2DSignedLength(trigObj->pos_.GetVelX(),
-                                                                       trigObj->pos_.GetVelY(),
-                                                                       object_->pos_.GetVelX(),
-                                                                       object_->pos_.GetVelY(),
-                                                                       rel_vel[0],
-                                                                       rel_vel[1]);
-
-                // calculate trig object relative speed as projected velocity absolute difference considering
-                rel_speed = SIGN(trigObj->GetSpeed()) * SIGN(proj_speed) * (proj_speed - fabs(object_->GetSpeed()));
-            }
-            // printf("rel_dist %.2f obj vel (%.2f, %.2f) speed %.2f trig_obj vel (%.2f, %.2f) speed %.2f proj_speed %.2f rel_speed %.2f\n",
-            //     rel_dist, object_->pos_.GetVelX(),
-            //     object_->pos_.GetVelY(),
-            //     object_->GetSpeed(),
-            //     trigObj->pos_.GetVelX(),
-            //     trigObj->pos_.GetVelY(),
-            //     trigObj->GetSpeed(),
-            //     proj_speed,
-            //     rel_speed);
-        }
-        else
-        {
             rel_speed = trigObj->speed_;
-        }
 
-        // TimeToCollision (TTC) not defined for cases:
-        //  - no distance between entities
-        //  - moving away from each other
-        if (fabs(rel_dist) < SMALL_NUMBER || fabs(rel_speed) < SMALL_NUMBER)
-        {
-            ttc_ = -1;
-        }
-        else
-        {
-            ttc_ = rel_dist / rel_speed;
-
-            if (ttc_ < 0.0)
+            // TimeToCollision (TTC) not defined for cases:
+            //  - no distance between entities
+            //  - moving away from each other
+            if (fabs(rel_dist) < SMALL_NUMBER || fabs(rel_speed) < SMALL_NUMBER)
             {
-                ttc_ = -1.0;
+                ttc_ = -1;
             }
             else
             {
-                result = EvaluateRule(ttc_, value_, rule_);
+                ttc_ = rel_dist / rel_speed;
+
+                if (ttc_ < 0.0)
+                {
+                    ttc_ = -1.0;
+                }
             }
+        }
+
+        if (ttc_ >= 0.0)
+        {
+            result = EvaluateRule(ttc_, value_, rule_);
 
             if (result == true)
             {

--- a/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCCondition.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/OSCTypeDefs/OSCCondition.cpp
@@ -790,8 +790,7 @@ bool TrigByTimeToCollision::CheckCondition(double sim_time)
     (void)sim_time;
 
     triggered_by_entities_.clear();
-    bool   result   = false;
-    double rel_dist = LARGE_NUMBER, rel_speed = 0.0;
+    bool result = false;
 
     ttc_ = -1;
 
@@ -804,8 +803,6 @@ bool TrigByTimeToCollision::CheckCondition(double sim_time)
             continue;
         }
 
-        int retVal = 0;
-
         if (object_ != nullptr)
         {
             if (!object_->IsActive())
@@ -816,14 +813,13 @@ bool TrigByTimeToCollision::CheckCondition(double sim_time)
         }
         else
         {
-            roadmanager::Position* pos = position_->GetRMPos();
-            retVal                     = trigObj->Distance(pos->GetX(), pos->GetY(), cs_, relDistType_, freespace_, rel_dist);
-
-            if (retVal != 0)
+            roadmanager::Position* pos      = position_->GetRMPos();
+            double                 rel_dist = LARGE_NUMBER;
+            if (trigObj->Distance(pos->GetX(), pos->GetY(), cs_, relDistType_, freespace_, rel_dist) != 0)
             {
                 rel_dist = LARGE_NUMBER;
             }
-            rel_speed = trigObj->speed_;
+            double rel_speed = trigObj->speed_;
 
             // TimeToCollision (TTC) not defined for cases:
             //  - no distance between entities

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/Entities.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/Entities.cpp
@@ -1348,6 +1348,66 @@ int Object::TimeHeadway(Object*                           target,
     return 0;
 }
 
+int Object::TimeToCollision(Object*                           target,
+                            roadmanager::CoordinateSystem     cs,
+                            roadmanager::RelativeDistanceType relDistType,
+                            bool                              freeSpace,
+                            double&                           ttc,
+                            double                            maxDist)
+{
+    ttc = -1;
+
+    if (target == nullptr)
+    {
+        return -1;
+    }
+
+    double rel_dist  = LARGE_NUMBER;
+    double rel_speed = 0.0;
+
+    if (this->Distance(target, cs, relDistType, freeSpace, rel_dist, maxDist) != 0)
+    {
+        rel_dist = LARGE_NUMBER;
+    }
+
+    if (fabs(target->pos_.GetVelX()) < SMALL_NUMBER && fabs(target->pos_.GetVelY()) < SMALL_NUMBER)
+    {
+        // target standing still, consider only speed of triggering entity
+        rel_speed = this->GetSpeed();
+    }
+    else
+    {
+        double rel_vel[2] = {0.0, 0.0};
+        // Calculate relative speed along target's velocity direction
+        double proj_speed = ProjectPointOnVector2DSignedLength(this->pos_.GetVelX(),
+                                                               this->pos_.GetVelY(),
+                                                               target->pos_.GetVelX(),
+                                                               target->pos_.GetVelY(),
+                                                               rel_vel[0],
+                                                               rel_vel[1]);
+
+        rel_speed = SIGN(this->GetSpeed()) * SIGN(proj_speed) * (proj_speed - fabs(target->GetSpeed()));
+    }
+
+    // TTC not defined for cases:
+    //  - no distance between entities
+    //  - moving away from each other
+    if (fabs(rel_dist) < SMALL_NUMBER || fabs(rel_speed) < SMALL_NUMBER)
+    {
+        ttc = -1;
+    }
+    else
+    {
+        ttc = rel_dist / rel_speed;
+        if (ttc < 0.0)
+        {
+            ttc = -1.0;
+        }
+    }
+
+    return 0;
+}
+
 Object::OverlapType Object::OverlappingFront(Object* target, double tolerance)
 {
     // Strategy:

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/Entities.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/Entities.hpp
@@ -458,6 +458,13 @@ namespace scenarioengine
                         double&                           thw,
                         double                            maxDist = LARGE_NUMBER);
 
+        int TimeToCollision(Object*                           target,
+                            roadmanager::CoordinateSystem     cs,
+                            roadmanager::RelativeDistanceType relDistType,
+                            bool                              freeSpace,
+                            double&                           ttc,
+                            double                            maxDist = LARGE_NUMBER);
+
         enum class OverlapType
         {
             NONE            = 0,             // object is not overlapping Ego front projection

--- a/EnvironmentSimulator/Unittest/ScenarioEngineDll_test.cpp
+++ b/EnvironmentSimulator/Unittest/ScenarioEngineDll_test.cpp
@@ -6356,6 +6356,27 @@ TEST_P(TrailTest, TrailTestPositionMode)
     SE_Close();
 }
 
+TEST(APITest, TestGetTimeToCollision)
+{
+    std::string scenario_file = "../../../EnvironmentSimulator/Unittest/xosc/ttc_condition.xosc";
+
+    ASSERT_EQ(SE_Init(scenario_file.c_str(), 0, 0, 0, 0), 0);
+    ASSERT_GE(SE_GetNumberOfObjects(), 2);
+
+    double ttc = 42.0;
+
+    // Invalid object id -> error
+    EXPECT_EQ(SE_GetTimeToCollision(999, 0, 1, SE_RelativeDistanceType::REL_DIST_LONGITUDINAL, false, &ttc), -1);
+
+    // Null pointer -> error
+    EXPECT_EQ(SE_GetTimeToCollision(0, 1, 1, SE_RelativeDistanceType::REL_DIST_LONGITUDINAL, false, nullptr), -1);
+
+    // Valid call -> success (ttc may be -1 if undefined in this frame)
+    EXPECT_EQ(SE_GetTimeToCollision(0, 1, 1, SE_RelativeDistanceType::REL_DIST_LONGITUDINAL, false, &ttc), 0);
+
+    SE_Close();
+}
+
 INSTANTIATE_TEST_SUITE_P(
     TrailTestPositionModePosition,
     TrailTest,


### PR DESCRIPTION
Hi, thanks for the great project!

Add time-to-collision computation as `Object::TimeToCollision` and expose it via `SE_GetTimeToCollision` in esminiLib.
`TrigByTimeToCollision::CheckCondition` delegates the object-to-object path to the new method (no behavior change).