### PR TITLE
Expose TTC computation to esminiJS API

### DIFF
--- a/EnvironmentSimulator/Libraries/esminiJS/README.md
+++ b/EnvironmentSimulator/Libraries/esminiJS/README.md
@@ -136,6 +136,7 @@ Main methods on `OpenScenario`:
 - `get_object_count()` returns the current active object count
 - `get_simulation_time()` returns current simulation time in seconds
 - `is_quit()` reports whether the scenario has completed
+- `time_to_collision(object_a_id, object_b_id, free_space, cs, dist_type)` returns the time to collision in seconds from object A to object B, or `-1` when undefined. `cs` and `dist_type` are the integer values of `roadmanager::CoordinateSystem` and `roadmanager::RelativeDistanceType`
 
 Configuration values exposed through embind `value_object` types are passed from JavaScript as plain object literals, for example:
 

--- a/EnvironmentSimulator/Libraries/esminiJS/embind.cpp
+++ b/EnvironmentSimulator/Libraries/esminiJS/embind.cpp
@@ -154,7 +154,7 @@ namespace esmini
             .function("is_quit", &OpenScenario::is_quit)
             .function("get_object_state", &OpenScenario::get_object_state, emscripten::allow_raw_pointers())
             .function("get_object_state_by_second", &OpenScenario::get_object_state_by_second)
-            .function("get_time_to_collision", &OpenScenario::get_time_to_collision);
+            .function("time_to_collision", &OpenScenario::time_to_collision);
     }
 }  // namespace esmini
 

--- a/EnvironmentSimulator/Libraries/esminiJS/embind.cpp
+++ b/EnvironmentSimulator/Libraries/esminiJS/embind.cpp
@@ -154,7 +154,7 @@ namespace esmini
             .function("is_quit", &OpenScenario::is_quit)
             .function("get_object_state", &OpenScenario::get_object_state, emscripten::allow_raw_pointers())
             .function("get_object_state_by_second", &OpenScenario::get_object_state_by_second)
-            .function("get_ttc", &OpenScenario::get_ttc);
+            .function("get_time_to_collision", &OpenScenario::get_time_to_collision);
     }
 }  // namespace esmini
 

--- a/EnvironmentSimulator/Libraries/esminiJS/embind.cpp
+++ b/EnvironmentSimulator/Libraries/esminiJS/embind.cpp
@@ -153,7 +153,8 @@ namespace esmini
             .function("get_simulation_time", &OpenScenario::get_simulation_time)
             .function("is_quit", &OpenScenario::is_quit)
             .function("get_object_state", &OpenScenario::get_object_state, emscripten::allow_raw_pointers())
-            .function("get_object_state_by_second", &OpenScenario::get_object_state_by_second);
+            .function("get_object_state_by_second", &OpenScenario::get_object_state_by_second)
+            .function("get_ttc", &OpenScenario::get_ttc);
     }
 }  // namespace esmini
 

--- a/EnvironmentSimulator/Libraries/esminiJS/esminijs.cpp
+++ b/EnvironmentSimulator/Libraries/esminiJS/esminijs.cpp
@@ -675,6 +675,32 @@ namespace esmini
         return copy_state_from_object(object, scenario_engine_->getSimulationTime());
     }
 
+    double OpenScenario::get_ttc(int object_a_id, int object_b_id, bool free_space, int cs, int dist_type) const
+    {
+        if (scenario_engine_ == nullptr)
+        {
+            return -1.0;
+        }
+
+        scenarioengine::Object* obj_a = scenario_engine_->entities_.GetObjectById(object_a_id);
+        scenarioengine::Object* obj_b = scenario_engine_->entities_.GetObjectById(object_b_id);
+        if (obj_a == nullptr || obj_b == nullptr)
+        {
+            return -1.0;
+        }
+
+        double ttc = -1.0;
+        if (obj_a->TimeToCollision(obj_b,
+                                   static_cast<roadmanager::CoordinateSystem>(cs),
+                                   static_cast<roadmanager::RelativeDistanceType>(dist_type),
+                                   free_space,
+                                   ttc) != 0)
+        {
+            return -1.0;
+        }
+        return ttc;
+    }
+
     ScenarioRoadGeometry OpenScenario::collect_road_geometry() const
     {
         ScenarioRoadGeometry geometry;

--- a/EnvironmentSimulator/Libraries/esminiJS/esminijs.cpp
+++ b/EnvironmentSimulator/Libraries/esminiJS/esminijs.cpp
@@ -675,7 +675,7 @@ namespace esmini
         return copy_state_from_object(object, scenario_engine_->getSimulationTime());
     }
 
-    double OpenScenario::get_time_to_collision(int object_a_id, int object_b_id, bool free_space, int cs, int dist_type) const
+    double OpenScenario::time_to_collision(int object_a_id, int object_b_id, bool free_space, int cs, int dist_type) const
     {
         if (scenario_engine_ == nullptr)
         {

--- a/EnvironmentSimulator/Libraries/esminiJS/esminijs.cpp
+++ b/EnvironmentSimulator/Libraries/esminiJS/esminijs.cpp
@@ -675,7 +675,7 @@ namespace esmini
         return copy_state_from_object(object, scenario_engine_->getSimulationTime());
     }
 
-    double OpenScenario::get_ttc(int object_a_id, int object_b_id, bool free_space, int cs, int dist_type) const
+    double OpenScenario::get_time_to_collision(int object_a_id, int object_b_id, bool free_space, int cs, int dist_type) const
     {
         if (scenario_engine_ == nullptr)
         {

--- a/EnvironmentSimulator/Libraries/esminiJS/esminijs.cpp
+++ b/EnvironmentSimulator/Libraries/esminiJS/esminijs.cpp
@@ -683,21 +683,19 @@ namespace esmini
         }
 
         scenarioengine::Object* obj_a = scenario_engine_->entities_.GetObjectById(object_a_id);
-        scenarioengine::Object* obj_b = scenario_engine_->entities_.GetObjectById(object_b_id);
-        if (obj_a == nullptr || obj_b == nullptr)
+        if (obj_a == nullptr)
         {
             return -1.0;
         }
 
+        scenarioengine::Object* obj_b = scenario_engine_->entities_.GetObjectById(object_b_id);
+
         double ttc = -1.0;
-        if (obj_a->TimeToCollision(obj_b,
-                                   static_cast<roadmanager::CoordinateSystem>(cs),
-                                   static_cast<roadmanager::RelativeDistanceType>(dist_type),
-                                   free_space,
-                                   ttc) != 0)
-        {
-            return -1.0;
-        }
+        obj_a->TimeToCollision(obj_b,
+                               static_cast<roadmanager::CoordinateSystem>(cs),
+                               static_cast<roadmanager::RelativeDistanceType>(dist_type),
+                               free_space,
+                               ttc);
         return ttc;
     }
 

--- a/EnvironmentSimulator/Libraries/esminiJS/esminijs.hpp
+++ b/EnvironmentSimulator/Libraries/esminiJS/esminijs.hpp
@@ -188,6 +188,8 @@ namespace esmini
         bool                             is_quit() const;
         void                             reset();
 
+        double get_ttc(int object_a_id, int object_b_id, bool free_space = true, int cs = 1, int dist_type = 2) const;
+
         OpenScenario(const OpenScenario&)            = delete;
         OpenScenario& operator=(const OpenScenario&) = delete;
 

--- a/EnvironmentSimulator/Libraries/esminiJS/esminijs.hpp
+++ b/EnvironmentSimulator/Libraries/esminiJS/esminijs.hpp
@@ -188,7 +188,7 @@ namespace esmini
         bool                             is_quit() const;
         void                             reset();
 
-        double time_to_collision(int object_a_id, int object_b_id, bool free_space = true, int cs = 1, int dist_type = 2) const;
+        double time_to_collision(int object_a_id, int object_b_id, bool free_space, int cs, int dist_type) const;
 
         OpenScenario(const OpenScenario&)            = delete;
         OpenScenario& operator=(const OpenScenario&) = delete;

--- a/EnvironmentSimulator/Libraries/esminiJS/esminijs.hpp
+++ b/EnvironmentSimulator/Libraries/esminiJS/esminijs.hpp
@@ -188,7 +188,7 @@ namespace esmini
         bool                             is_quit() const;
         void                             reset();
 
-        double get_time_to_collision(int object_a_id, int object_b_id, bool free_space = true, int cs = 1, int dist_type = 2) const;
+        double time_to_collision(int object_a_id, int object_b_id, bool free_space = true, int cs = 1, int dist_type = 2) const;
 
         OpenScenario(const OpenScenario&)            = delete;
         OpenScenario& operator=(const OpenScenario&) = delete;

--- a/EnvironmentSimulator/Libraries/esminiJS/esminijs.hpp
+++ b/EnvironmentSimulator/Libraries/esminiJS/esminijs.hpp
@@ -188,7 +188,7 @@ namespace esmini
         bool                             is_quit() const;
         void                             reset();
 
-        double get_ttc(int object_a_id, int object_b_id, bool free_space = true, int cs = 1, int dist_type = 2) const;
+        double get_time_to_collision(int object_a_id, int object_b_id, bool free_space = true, int cs = 1, int dist_type = 2) const;
 
         OpenScenario(const OpenScenario&)            = delete;
         OpenScenario& operator=(const OpenScenario&) = delete;


### PR DESCRIPTION
Follow-up to #821, which added TTC to the esminiLib C API.

This adds the same `Object::TimeToCollision` computation to the esminiJS (WASM)
API, so it can be called from the browser build via `get_ttc`.