### PR TITLE
Fix standalone esminiJS WASM build: generate CommonMini/version.cpp

### DIFF
--- a/EnvironmentSimulator/Libraries/esminiJS/CMakeLists.txt
+++ b/EnvironmentSimulator/Libraries/esminiJS/CMakeLists.txt
@@ -17,6 +17,24 @@ set(CMAKE_CXX_STANDARD
 
 project(${TARGET})
 
+# Generate CommonMini/version.cpp for the standalone esminiJS build.
+#
+# CommonMini.cpp references the symbols ESMINI_GIT_REV, ESMINI_GIT_TAG, ESMINI_GIT_BRANCH and ESMINI_BUILD_VERSION, which are *defined* in a generated
+# version.cpp (produced from version.cpp.in by CommonMini/version.cmake). The full esmini build generates it via CommonMini/CMakeLists.txt; this
+# standalone build never did, so linking failed with "undefined symbol: ESMINI_GIT_REV" (and the other three). The COMMONMINI_SOURCES glob below
+# already matches version.cpp once it exists, so generating it here is sufficient.
+set(COMMON_MINI_SOURCE_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../Modules/CommonMini")
+if(NOT
+   DEFINED
+   ESMINI_BUILD_VERSION)
+    set(ESMINI_BUILD_VERSION
+        "N/A")
+endif()
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -DESMINI_BUILD_VERSION=${ESMINI_BUILD_VERSION} -P ${COMMON_MINI_SOURCE_DIR}/version.cmake
+    WORKING_DIRECTORY ${COMMON_MINI_SOURCE_DIR})
+
 set(SCENARIOENGINE_INCLUDE_DIRS
     "${CMAKE_CURRENT_SOURCE_DIR}/../../Modules/ScenarioEngine/SourceFiles"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../Modules/ScenarioEngine/OSCTypeDefs")


### PR DESCRIPTION
## Problem

Building the standalone **esminiJS** Emscripten/WASM target
(`EnvironmentSimulator/Libraries/esminiJS`, per its `build.sh` / `CMakeLists.txt`)
compiles all objects but then **fails to link**:

```
undefined symbol: ESMINI_GIT_REV
undefined symbol: ESMINI_GIT_TAG
undefined symbol: ESMINI_GIT_BRANCH
undefined symbol: ESMINI_BUILD_VERSION
```

Those symbols are referenced by `CommonMini.cpp` and *defined* in a generated
`version.cpp` (produced from `version.cpp.in` by `CommonMini/version.cmake`). The
full esmini build generates it via `CommonMini/CMakeLists.txt`, but the standalone
`esminiJS` target never triggers that generation, so `version.cpp` is missing from
the link.

## Fix

Invoke `version.cmake` from the `esminiJS` `CMakeLists.txt` exactly the way
`CommonMini/CMakeLists.txt` already does
(`cmake -DESMINI_BUILD_VERSION=... -P version.cmake`). The existing
`COMMONMINI_SOURCES` glob then picks up the generated `CommonMini/version.cpp`, so
no source-list change is needed. 20 lines, one file.

Under a shallow checkout `git describe` yields nothing and the values resolve to
`"N/A"`, which is harmless.

## Verification

With this change the `esminiJS` target builds and links standalone via
`emcmake cmake -G Ninja -DCMAKE_BUILD_TYPE=Release` + `SINGLE_FILE=1`, producing a
working `esmini.js`. I ran it in headless Chromium: `get_road_geometry()` returns
lane surfaces / lane centers and `step_frame()` advances entities, with `reset()`
restarting the run (endless-loop playback).

Refs #357.

## Note

Happy to follow up on distribution (an npm package / a prebuilt WASM release asset)
if that's useful — there is currently no published artifact, which is the main thing
keeping downstream projects from consuming esminiJS directly.
