### PR TITLE
 Fix NaturalDriver crash when running without a ScenarioPlayer 

### DIFF
--- a/EnvironmentSimulator/Modules/Controllers/ControllerNaturalDriver.cpp
+++ b/EnvironmentSimulator/Modules/Controllers/ControllerNaturalDriver.cpp
@@ -16,6 +16,7 @@
 
 #include "ControllerNaturalDriver.hpp"
 #include "playerbase.hpp"
+#include "OSCPrivateAction.hpp"
 
 using namespace scenarioengine;
 
@@ -170,8 +171,29 @@ void ControllerNaturalDriver::Step(double dt)
         }
         else
         {
-            auto lane_change = LaneChangeActionStruct{object_->GetId(), 0, target_lane_, 2, 2, lane_change_duration_};
-            player_->player_server_->InjectLaneChangeAction(lane_change);
+            if (player_ != nullptr && player_->player_server_ != nullptr)
+            {
+                auto lane_change = LaneChangeActionStruct{object_->GetId(), 0, target_lane_, 2, 2, lane_change_duration_};
+                player_->player_server_->InjectLaneChangeAction(lane_change);
+            }
+            else
+            {
+                // No ScenarioPlayer (headless library mode): build the same action as
+                // PlayerServer::InjectLaneChangeAction and inject it through the engine
+                LatLaneChangeAction* a = new LatLaneChangeAction(nullptr);
+                a->SetName("NaturalDriverLaneChange");
+                a->object_                = object_;
+                a->transition_.shape_     = OSCPrivateAction::DynamicsShape::SINUSOIDAL;
+                a->transition_.dimension_ = OSCPrivateAction::DynamicsDimension::TIME;
+                a->transition_.SetParamTargetVal(lane_change_duration_);
+                a->max_num_executions_ = 1;
+
+                LatLaneChangeAction::TargetAbsolute* target = new LatLaneChangeAction::TargetAbsolute;
+                target->value_                              = target_lane_;
+                a->target_                                  = target;
+
+                scenario_engine_->AddInjectedAction(a);
+            }
             lane_change_injected = true;
         }
 

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.cpp
@@ -109,12 +109,49 @@ int ScenarioEngine::InitScenario(const pugi::xml_document& xml_doc, bool disable
 
 ScenarioEngine::~ScenarioEngine()
 {
+    for (OSCAction* action : owned_injected_actions_)
+    {
+        delete action;
+    }
+    owned_injected_actions_.clear();
+
     scenarioReader->UnloadControllers();
     delete scenarioReader;
     scenarioReader = 0;
     SE_Env::Inst().SetOSCFilePath("");
     LOG_INFO("Closing");
     txtLogger.SetLoggerTime(nullptr);
+}
+
+int ScenarioEngine::AddInjectedAction(OSCAction* action)
+{
+    LOG_INFO("Adding action {}", action->GetName());
+
+    // Ensure there is a list to inject into. If no external list (e.g. PlayerServer's) has been
+    // registered, fall back to the engine-owned list so controllers can inject without a player.
+    if (injected_actions_ == nullptr)
+    {
+        injected_actions_ = &owned_injected_actions_;
+    }
+
+    // abort any action of same type and object
+    for (auto& a : *injected_actions_)
+    {
+        if (a->action_type_ == action->action_type_ &&
+            ((a->GetBaseType() != OSCAction::BaseType::PRIVATE) ||
+             (static_cast<OSCPrivateAction*>(a)->object_ == static_cast<OSCPrivateAction*>(action)->object_)))
+        {
+            LOG_WARN("Action {} of type {} already ongoing{}, stopping it",
+                     a->GetName(),
+                     a->Type2Str(),
+                     a->GetBaseType() == OSCAction::BaseType::PRIVATE ? (" for " + static_cast<OSCPrivateAction*>(a)->object_->GetName()) : "");
+            a->End();
+        }
+    }
+
+    injected_actions_->push_back(action);
+
+    return 0;
 }
 
 void ScenarioEngine::UpdateGhostMode()
@@ -186,6 +223,26 @@ int ScenarioEngine::step(double deltaSimTime)
             else
             {
                 action->Step(simulationTime_, deltaSimTime);
+            }
+        }
+    }
+
+    // When the engine owns the injected-actions list (headless library mode, no PlayerServer),
+    // reap completed actions here since there is no PlayerServer::Step() to do it.
+    // In the native ScenarioPlayer path injected_actions_ points elsewhere, so this is skipped.
+    if (injected_actions_ == &owned_injected_actions_)
+    {
+        for (size_t i = 0; i < owned_injected_actions_.size();)
+        {
+            if (owned_injected_actions_[i]->GetCurrentState() == OSCAction::State::COMPLETE)
+            {
+                LOG_INFO("Injected action {} finished", owned_injected_actions_[i]->GetName());
+                delete owned_injected_actions_[i];
+                owned_injected_actions_.erase(owned_injected_actions_.begin() + static_cast<long>(i));
+            }
+            else
+            {
+                ++i;
             }
         }
     }

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/ScenarioEngine.hpp
@@ -63,6 +63,12 @@ namespace scenarioengine
             injected_actions_ = injected_actions;
         }
 
+        // Inject a runtime action into the scenario, taking ownership if no external
+        // injected-actions list (e.g. PlayerServer's) has been registered via
+        // SetInjectedActionsPtr (headless library mode). The engine is agnostic to the
+        // action type; callers build the action themselves.
+        int AddInjectedAction(OSCAction *action);
+
         /**
         Step scenario, i.e. evaluate conditions and step actions
         @param deltaSimTime timestep
@@ -186,6 +192,11 @@ namespace scenarioengine
         Vehicle sumotemplate;
         Object *ghost_;
         double  ghost_trail_dt_;
+
+        // Engine-owned injected actions, used only when no external list (e.g. PlayerServer's)
+        // has been registered via SetInjectedActionsPtr. Kept separate so the ScenarioPlayer
+        // path is completely unaffected.
+        std::vector<OSCAction *> owned_injected_actions_;
 
         // Distance map
         struct DistanceMeasurement

--- a/EnvironmentSimulator/Unittest/ScenarioEngine_test.cpp
+++ b/EnvironmentSimulator/Unittest/ScenarioEngine_test.cpp
@@ -6509,6 +6509,46 @@ TEST(InitActions, TestInitActionsReorderingNoGhost)
     delete se;
 }
 
+// NaturalDriver without a ScenarioPlayer must inject lane changes through the engine, not crash.
+TEST(ControllerTest, NaturalDriverHeadlessLaneChange)
+{
+    ScenarioEngine* se = new ScenarioEngine("../../../resources/xosc/highway_driver.xosc");
+    ASSERT_NE(se, nullptr);
+
+    scenario_step(se, 0.0);
+
+    Object* ego           = se->entities_.object_[0];
+    int     initial_lane  = ego->pos_.GetLaneId();
+    double  initial_speed = ego->GetSpeed();
+    EXPECT_EQ(initial_lane, -3);
+    EXPECT_NEAR(initial_speed, 25.0, 1e-3);
+
+    int  lane_after_1s = initial_lane;
+    bool lane_changed  = false;
+    for (int i = 0; i < 200; ++i)
+    {
+        scenario_step(se, 0.05);
+        int lane = ego->pos_.GetLaneId();
+        if (lane != initial_lane)
+        {
+            lane_changed = true;
+        }
+        if (i == 20)  // t = 1.05 s
+        {
+            lane_after_1s = lane;
+        }
+    }
+
+    EXPECT_TRUE(lane_changed);
+    EXPECT_EQ(lane_after_1s, -2);
+    EXPECT_EQ(ego->pos_.GetLaneId(), -2);
+
+    EXPECT_LT(ego->GetSpeed(), initial_speed);
+    EXPECT_NEAR(se->getSimulationTime(), 10.0, 1e-6);
+
+    delete se;
+}
+
 int main(int argc, char** argv)
 {
 #if 0  // set to 1 and modify filter to run one single test


### PR DESCRIPTION
This reports the issue and proposes a possible fix. I’m happy to follow whichever approach the maintainers prefer.

`ControllerNaturalDriver::Step()` injects lane changes via `player_->player_server_`, which is `nullptr` in headless library mode (e.g. esminiJS drives the `ScenarioEngine` directly). The first lane change in `highway_driver.xosc` then crashes.

Fix: add a generic `ScenarioEngine::AddInjectedAction(OSCAction*)` backed by an engine-owned list, used when no `PlayerServer` list is registered. The controller builds the `LatLaneChangeAction` and injects it through this entry point when no player exists. The native path is unchanged (`PlayerBase/` untouched).

Includes a unit test that crashes without the fix.