### PR TITLE
Fix TTC closing speed to account for relative position

### DIFF
--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/Entities.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/Entities.cpp
@@ -1362,47 +1362,40 @@ int Object::TimeToCollision(Object*                           target,
         return -1;
     }
 
-    double rel_dist  = LARGE_NUMBER;
-    double rel_speed = 0.0;
+    double rel_dist = LARGE_NUMBER;
 
     if (this->Distance(target, cs, relDistType, freeSpace, rel_dist, maxDist) != 0)
     {
         rel_dist = LARGE_NUMBER;
     }
 
-    if (fabs(target->pos_.GetVelX()) < SMALL_NUMBER && fabs(target->pos_.GetVelY()) < SMALL_NUMBER)
-    {
-        // target standing still, consider only speed of triggering entity
-        rel_speed = this->GetSpeed();
-    }
-    else
-    {
-        double rel_vel[2] = {0.0, 0.0};
-        // Calculate relative speed along target's velocity direction
-        double proj_speed = ProjectPointOnVector2DSignedLength(this->pos_.GetVelX(),
-                                                               this->pos_.GetVelY(),
-                                                               target->pos_.GetVelX(),
-                                                               target->pos_.GetVelY(),
-                                                               rel_vel[0],
-                                                               rel_vel[1]);
+    // Closing speed is the relative velocity projected on the line of sight towards
+    // the target, positive when the gap is shrinking
+    double los_x      = target->pos_.GetX() - this->pos_.GetX();
+    double los_y      = target->pos_.GetY() - this->pos_.GetY();
+    double los_length = sqrt(los_x * los_x + los_y * los_y);
 
-        rel_speed = SIGN(this->GetSpeed()) * SIGN(proj_speed) * (proj_speed - fabs(target->GetSpeed()));
+    double closing_speed = 0.0;
+    if (los_length > SMALL_NUMBER)
+    {
+        double rel_vel_x = this->pos_.GetVelX() - target->pos_.GetVelX();
+        double rel_vel_y = this->pos_.GetVelY() - target->pos_.GetVelY();
+
+        closing_speed = (rel_vel_x * los_x + rel_vel_y * los_y) / los_length;
     }
 
     // TTC not defined for cases:
     //  - no distance between entities
-    //  - moving away from each other
-    if (fabs(rel_dist) < SMALL_NUMBER || fabs(rel_speed) < SMALL_NUMBER)
+    //  - entities not approaching each other
+    if (fabs(rel_dist) < SMALL_NUMBER || closing_speed < SMALL_NUMBER)
     {
         ttc = -1;
     }
     else
     {
-        ttc = rel_dist / rel_speed;
-        if (ttc < 0.0)
-        {
-            ttc = -1.0;
-        }
+        // Distance() is signed by the direction to the target, e.g. negative when behind.
+        // The direction is already covered by the closing speed, use the gap size only
+        ttc = fabs(rel_dist) / closing_speed;
     }
 
     return 0;

--- a/EnvironmentSimulator/Unittest/ScenarioEngine_test.cpp
+++ b/EnvironmentSimulator/Unittest/ScenarioEngine_test.cpp
@@ -3286,6 +3286,64 @@ TEST(ConditionTest, TestTTC)
     EvaluateRelativeSpeed(trig_obj, obj, t, 7.0 * M_PI_4);
 }
 
+static void EvaluateCrossingPair(Object& trig_obj, Object& obj, TrigByTimeToCollision& t, double heading)
+{
+    double obj_pos[2]      = {0.0, 0.0};
+    double trig_obj_pos[2] = {0.0, 0.0};
+
+    // object behind triggering object, crossing its path at a right angle, so that the
+    // triggering object drives away from it and the gap grows by 10 m/s
+    RotateVec2D(0.0, 0.0, heading, trig_obj_pos[0], trig_obj_pos[1]);
+    trig_obj.pos_.SetInertiaPos(trig_obj_pos[0], trig_obj_pos[1], heading, false);
+    RotateVec2D(-100.0, 0.0, heading, obj_pos[0], obj_pos[1]);
+    obj.pos_.SetInertiaPos(obj_pos[0], obj_pos[1], heading + M_PI_2, false);
+
+    trig_obj.SetSpeed(10.0);
+    trig_obj.SetVel(trig_obj.GetSpeed() * cos(trig_obj.pos_.GetH()), trig_obj.GetSpeed() * sin(trig_obj.pos_.GetH()), 0.0);
+    obj.SetSpeed(10.0);
+    obj.SetVel(obj.GetSpeed() * cos(obj.pos_.GetH()), obj.GetSpeed() * sin(obj.pos_.GetH()), 0.0);
+    EXPECT_EQ(t.CheckCondition(0.0), false);
+    EXPECT_NEAR(t.ttc_, -1.0, 1e-3);
+
+    // object in front of triggering object, crossing its path at a right angle, so that
+    // the triggering object approaches it and the gap shrinks by 10 m/s
+    RotateVec2D(100.0, 0.0, heading, obj_pos[0], obj_pos[1]);
+    obj.pos_.SetInertiaPos(obj_pos[0], obj_pos[1], heading + M_PI_2, false);
+
+    obj.SetSpeed(10.0);
+    obj.SetVel(obj.GetSpeed() * cos(obj.pos_.GetH()), obj.GetSpeed() * sin(obj.pos_.GetH()), 0.0);
+    EXPECT_EQ(t.CheckCondition(0.0), false);
+    EXPECT_NEAR(t.ttc_, 10.0, 1e-3);
+}
+
+TEST(ConditionTest, TestTTCCrossingPaths)
+{
+    Object trig_obj(Object::Type::VEHICLE);
+    Object obj(Object::Type::VEHICLE);
+
+    TrigByTimeToCollision t;
+    t.object_                 = &obj;
+    t.triggering_entity_rule_ = TrigByTimeToCollision::TriggeringEntitiesRule::ANY;
+    t.triggering_entities_.entity_.push_back({&trig_obj});
+    t.value_       = 3.0;
+    t.freespace_   = false;
+    t.cs_          = roadmanager::CoordinateSystem::CS_ENTITY;
+    t.relDistType_ = roadmanager::RelativeDistanceType::REL_DIST_EUCLIDIAN;
+    t.rule_        = Rule::LESS_OR_EQUAL;
+
+    trig_obj.SetActive(true);
+    obj.SetActive(true);
+
+    EvaluateCrossingPair(trig_obj, obj, t, 0.0 * M_PI_4);
+    EvaluateCrossingPair(trig_obj, obj, t, 1.0 * M_PI_4);
+    EvaluateCrossingPair(trig_obj, obj, t, 2.0 * M_PI_4);
+    EvaluateCrossingPair(trig_obj, obj, t, 3.0 * M_PI_4);
+    EvaluateCrossingPair(trig_obj, obj, t, 4.0 * M_PI_4);
+    EvaluateCrossingPair(trig_obj, obj, t, 5.0 * M_PI_4);
+    EvaluateCrossingPair(trig_obj, obj, t, 6.0 * M_PI_4);
+    EvaluateCrossingPair(trig_obj, obj, t, 7.0 * M_PI_4);
+}
+
 static void TTCAndLateralDistParamDeclCallback(void*)
 {
     static int counter = 0;

--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -1777,7 +1777,7 @@ class TestSuite(unittest.TestCase):
 
         # Check some scenario events
         self.assertTrue(re.search('.0.600.* ped_walk_event: true, delay: 0.00, traveled_dist: 6.00 >= 5.00, edge: rising', log)  is not None)
-        self.assertTrue(re.search('.3.800.* brake_Condition: true, delay: 0.00, TTC: 1.20 < 1.20, edge rising', log)  is not None)
+        self.assertTrue(re.search('.3.900.* brake_Condition: true, delay: 0.00, TTC: 1.14 < 1.20, edge rising', log)  is not None)
         self.assertTrue(re.search('.14.400.* QuitCondition: true, delay: 0.00, distance 4.87 < tolerance \\(5.00\\), edge: rising', log)  is not None)
 
         # Check vehicle key positions
@@ -1785,7 +1785,7 @@ class TestSuite(unittest.TestCase):
 
         self.assertTrue(re.search('^0.000, 0, Ego, 42.984, -71.249, 0.000, 1.776, 0.000, 0.000, 10.000, 0.000, 0.000', csv, re.MULTILINE))
         self.assertTrue(re.search('^0.000, 1, pedestrian_adult, 35.692, -23.629, 0.120, 1.798, 0.000, 0.000, 0.000, 0.000, 0.000', csv, re.MULTILINE))
-        self.assertTrue(re.search('^3.900, 0, Ego, 34.307, -33.282, 0.000, 1.803, 0.000, 0.000, 9.490, -0.001, 4.469', csv, re.MULTILINE))
+        self.assertTrue(re.search('^3.900, 0, Ego, 34.295, -33.232, 0.000, 1.803, 0.000, 0.000, 10.000, -0.001, 4.614', csv, re.MULTILINE))
         self.assertTrue(re.search('^3.900, 1, pedestrian_adult, 34.693, -19.282, 0.120, 1.795, 0.000, 0.000, 1.500, 0.000, 0.000', csv, re.MULTILINE))
         self.assertTrue(re.search('^4.100, 1, pedestrian_adult, 34.452, -19.114, 0.120, 2.415, 0.000, 0.000, 1.500, 0.000, 0.000', csv, re.MULTILINE))
         self.assertTrue(re.search('^4.200, 1, pedestrian_adult, 34.325, -19.034, 0.120, 2.749, 0.000, 0.000, 1.500, 0.000, 0.000', csv, re.MULTILINE))
@@ -1794,8 +1794,8 @@ class TestSuite(unittest.TestCase):
         self.assertTrue(re.search('^4.500, 1, pedestrian_adult, 33.921, -18.926, 0.120, 3.364, 0.000, 0.000, 1.500, 0.000, 0.000', csv, re.MULTILINE))
         self.assertTrue(re.search('^5.200, 1, pedestrian_adult, 32.897, -19.159, 0.120, 3.364, 0.000, 0.000, 1.500, 0.000, 0.000', csv, re.MULTILINE))
         self.assertTrue(re.search('^5.300, 1, pedestrian_adult, 32.751, -19.192, 0.000, 3.364, 0.000, 0.000, 1.500, 0.000, 0.000', csv, re.MULTILINE))
-        self.assertTrue(re.search('^5.600, 0, Ego, 32.406, -25.172, 0.000, 1.799, 0.000, 0.000, 0.820, -0.002, 3.136', csv, re.MULTILINE))
-        self.assertTrue(re.search('^5.700, 0, Ego, 32.399, -25.142, 0.000, 1.799, 0.000, 0.000, 0.310, -0.002, 3.225', csv, re.MULTILINE))
+        self.assertTrue(re.search('^5.600, 0, Ego, 32.198, -24.278, 0.000, 1.798, 0.000, 0.000, 1.330, -0.002, 5.759', csv, re.MULTILINE))
+        self.assertTrue(re.search('^5.700, 0, Ego, 32.180, -24.198, 0.000, 1.798, 0.000, 0.000, 0.820, -0.002, 5.993', csv, re.MULTILINE))
         self.assertTrue(re.search('^9.900, 1, pedestrian_adult, 26.023, -20.722, 0.000, 3.363, 0.000, 0.000, 1.500, 0.000, 0.000', csv, re.MULTILINE))
         self.assertTrue(re.search('^10.000, 1, pedestrian_adult, 25.876, -20.755, 0.120, 3.363, 0.000, 0.000, 1.500, 0.000, 0.000', csv, re.MULTILINE))
         self.assertTrue(re.search('^11.000, 1, pedestrian_adult, 24.456, -20.843, 0.120, 2.646, 0.000, 0.000, 1.500, 0.000, 0.000', csv, re.MULTILINE))


### PR DESCRIPTION
The closing speed in `Object::TimeToCollision()` is computed from the two velocity vectors only, ignoring where the target actually is. Entities moving apart can therefore report a small positive TTC, e.g. against a pedestrian walking away in traffic_lights.xosc. `TimeToCollisionCondition` shares this code, so it can misfire the same way.

Fix: project the relative velocity on the line of sight towards the target, so, for Euclidean distance, TTC is defined exactly when the gap is shrinking. Includes a unit test that fails without the fix, committed first so the issue can be reproduced by checking out that commit. Existing TTC unit test expectations are unchanged; one smoke test expectation (test_pedestrian) is updated — the corrected closing speed fires the brake condition one timestep later, matching the actual gap shrink rate.

<div align="center">

<img width="822" height="556" alt="image" src="https://github.com/user-attachments/assets/c2c52f7e-3599-4ef6-b352-12e407a44ecb" />

[Fig. Unit test](https://www.drawtonomy.com/?snapshot=eJy9WMlu40YQ_RWBAQIbkTm9L0rmEOQQzCUIkgA5RMGAFFsSbW6iqB3691RzESmR9ljATCwYoFpN9ntV1a9e8-RsnYmDXeqMnbUz-efkhAEMrJdeZib4JaL7NaE-_FjAaGH2BVzunQnDjLtUa44Y5owoMXYOzuSJKuQyQSVinDAuhRo7R2dCmB47IdzvIQTX8ITMmZycnTNReOwsnQkl4-rZgAS5KP6whjmzNEpzGMlNAN_maVL8GR4NPA1V3yxKL7Ez7a0_R-EigaHIzC1Eb1Ok1fQi35jzeXzFi-d-skvCiNe8ojAx6yIPk0XFDpVsUAVeIN6gx3DdoIf56Yv5OwwKIAA0sjRMik-BjWG9Cs3853WCo9SGthw5bqI0jWXOnH_HTpp5s7A4lDd7BazubwqzLh-98YtDZizcNALYZ5i8jj9Z_Dvv8AE7t3yIDKI1S6JdzWdrluEsMnWqqBSuVBhDWqgSnNWpwswVSkjFEcaK2FRBtHVFmiGEGtL2upMyisqUcdFmyI-82UuZhziLvMKUSNcm8BKnS_MWNebpMtvuadDJwmcvz9PdTRaucJEOLtLg6gcfF-p5j7YxvQT_2U-OBd7MVjb4DfTv5nNU8bvKJyyyNF5QVRCGtUtYdgiWcEwSvE2ss7YlVqKrk0EQc5nWGjYQbB4p62QI6sI_ERIrCimRJVuO-SULROBL6TXF0AZs0iuJlu27MWjpcgFjGIqECqlFAwK3IDi6B0RwEOGSsiKvQcQeBLfEQDUnrtJKMWaXIrzCAIu7GqpRE4YoFKtkJQZBuGow2OtuOQpWSQigtbW3t1xHH0fTaZqZ3CvSPPFic8ry9Pn8-TSdbs3stC2vrGqcCi9fmOJ8Po96P6W7BIY_jtB0Cj9a6Hl8AmmyU1cbLxg9vHLLdAorZ_0HNms9Ov2t08obFrdRnBVijZNAHvoqTBV3SW9rE8ldJARUkhCEYNXEUHdieK8K94F-BR1WMX1e8e3hOMDsWrTq-qBcXYmWlDU3gVpuoitXTN1ygyR9a17Fajc3cR7SPq9X-iaSQxkTuMMKd1g1Rd-yqorr27ZNwRdxEBc06dMiirmQEymxBl2G_NS8qB7kRTq8SIeXLdHbSkRxh9UiN4cnXgr2V6WWzXxKA3_LBpQKckNvlUozV0vNGJBCAEdXxFir1_a6Q4xIemmbjUxdROWvv345l5I1z73ZKTiftp9nnYEniMGVBp3PduxWluwddt92x9fnO7UmTZLtMRUrOVC5Qgx0DQYKxDSWlEgMoSCsiQTuRKJbuqpXupskLEZgfYpvvS1Tna2y1HuOe0lmjMkBIcWEusCUUMkF1hjXLREYsQ471mGHtezlGbLZJvO1pvH0Rr-An2ZBWtQzckj_dBptTd6OwEVuB-5Nt6fEJj3w1WbAJTDCXCUx9GFBGBOXLX3jG2sJlqKNCViGy6Z-j02YbU1iVhnaDqGwegmL2NVANvWXQPAOCHYPiATNQkYT8zLooV-xTMMwVKfVsutWO-CeK6G-0zvPY9_IHVmsv-SdSzhtd1Sd7tg3zZ5a4Q02R3MxzfsjAxAqR1emGaGvb5rnkS-WfM7i9zHCHUb4dUZyjnZoxmfqwijI0p2_Dg74ipFP7ec-RkmamDcpdcPZ313EFQQLoiUn5enrjYLCCLcGGIpc3FPYbQoHUIALR4jCYpJqQt_eXRaF7qBQ96Dg_kqss82C9LUXtNWVUhHCOEW6sUSCuQiOAwwpCkokJK8wwCTR0V7R3Vuy3ly81d5WdyF90Bmhbz4O-PlSXh9so7WTbqaA3vY7MCj6QA--U3671fnOQ9orqSHi4qmwfU1x1yntsiP6KKgEFJJzDqdCjan4IgraQXFXE-i-LenFQgk4mmp7HsbgJOtORJB2BRSugo8WTFYmzE5oKsQC6jWBJA3MB9Jbv3038871wQ71LaD9WTarc7BMg6vT_nF9tdm9yM1u198eDBbvWRNQD64pIZSDNQF3yivfhRXjl-XtG7grC8or58WurclPIwRF_ON0-ke4WBZlduDr6MqdlnVempJNEpg5pDGwY7Bj7j3Mxpg9LzfHvNHE1mBSRXDfaD9hTYeyDEQbRSyvux4M9c6zvpmnuRn9_se3tpjHeDF7oRu-6tFjcJAYspiv0tMdelendXrLzpsXJv8fyPlrfIjnOF_1ihTSJgde5wxruHWTqCV3fVyn1fFAX52TfLMIk5NnsdrCS2zZfv-xLdE_P_362_lhe22pQcTHNzOyaswPF9FDVlruykZve5679tPl3NwacPhLRvDXX7bfBQZWHpzTHwVMA4-7Xv7hB_xY_g_0n8fhtjRNplPwX5cI3rlniwXdxrvlEvfFCbyDKzXsXFBFJcGtl4nH0oVzoeIaC9AnSmp1solvfFt53VUnW8-QeKuevQNyFcP9Y3mMqoph5q2NjRcefT962FsRq8I0-qEemU4Xphq0zKvpX-RtX8tbQIAAipqDQ5OY2A0XpbBLMNXWqCihyfn8H6DMPt4)

</div>