### PR TITLE
Fix infinite loop in Object::Distance when target is a trailer

### DIFF
--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/Entities.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/Entities.cpp
@@ -1074,7 +1074,7 @@ int Object::Distance(Object*                           target,
             {
                 pivot_obj = pivot_obj->TowVehicle();
             }
-            while (target_obj->TowVehicle())
+            while (target_front_obj->TowVehicle())
             {
                 target_front_obj = target_front_obj->TowVehicle();
             }
@@ -1131,7 +1131,7 @@ int Object::Distance(Object*                           target,
             {
                 pivot_obj = pivot_obj->TowVehicle();
             }
-            while (target_obj->TowVehicle())
+            while (target_front_obj->TowVehicle())
             {
                 target_front_obj = target_front_obj->TowVehicle();
             }


### PR DESCRIPTION
The trailer-scanning loops check `target_obj->TowVehicle()` but only advance `target_front_obj`, so they never terminate when target is a trailer.

```
            while (target_obj->TowVehicle())
            {
                target_front_obj = target_front_obj->TowVehicle();
            }
 ```
 
In this PR, check the variable actually being advanced