### PR TITLE
Fix direct junction validation logging

### DIFF
--- a/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
+++ b/EnvironmentSimulator/Modules/RoadManager/RoadManager.cpp
@@ -6630,7 +6630,9 @@ int OpenDrive::CheckJunctionConnection(Junction* junction, Connection* connectio
                      connection->GetContactPoint() == ContactPointType::CONTACT_POINT_END &&
                      link[i]->GetContactPointType() == ContactPointType::CONTACT_POINT_JUNCTION && link[i]->GetElementId() != junction->GetId()))
                 {
-                    LOG_ERROR("Expected direct junction linkedRoad to connect back to junction id {}, found id {}", link[i]->GetElementId());
+                    LOG_ERROR("Expected direct junction linkedRoad to connect back to junction id {}, found id {}",
+                              junction->GetId(),
+                              link[i]->GetElementId());
                     return -1;
                 }
 


### PR DESCRIPTION
Fixes a fmt::format_error (argument not found) when validating a direct junction whose linked road points back to a different junction.

The diagnostic contained two format placeholders but supplied only one argument. This triggered an exception when using OpenDRIVE 1.9 example Ex_Slip_Lane.xodr (example contains an error).
