### PR TITLE
Issue 836

### DIFF
--- a/EnvironmentSimulator/Applications/replayer/osi_receiver.cpp
+++ b/EnvironmentSimulator/Applications/replayer/osi_receiver.cpp
@@ -22,7 +22,7 @@
 
 #ifndef _WINDOWS
 #include <unistd.h>
-#define Sleep(x) usleep((x) * 1000)
+#define Sleep(x) usleep((x)*1000)
 #endif
 
 static bool quit;

--- a/EnvironmentSimulator/Applications/replayer/osi_receiver.cpp
+++ b/EnvironmentSimulator/Applications/replayer/osi_receiver.cpp
@@ -22,7 +22,7 @@
 
 #ifndef _WINDOWS
 #include <unistd.h>
-#define Sleep(x) usleep((x)*1000)
+#define Sleep(x) usleep((x) * 1000)
 #endif
 
 static bool quit;

--- a/EnvironmentSimulator/Applications/replayer/osi_receiver.cpp
+++ b/EnvironmentSimulator/Applications/replayer/osi_receiver.cpp
@@ -45,7 +45,7 @@ typedef int SE_SOCKET;
 #define OSI_OUT_PORT          48198
 #define ES_SERV_TIMEOUT       500
 #define MAX_MSG_SIZE          1024000
-#define OSI_MAX_UDP_DATA_SIZE 8200
+#define OSI_MAX_UDP_DATA_SIZE 65536
 
 void CloseGracefully(SE_SOCKET socket)
 {

--- a/EnvironmentSimulator/Libraries/esminiLib/ESMiniWrapper.cs
+++ b/EnvironmentSimulator/Libraries/esminiLib/ESMiniWrapper.cs
@@ -1847,6 +1847,13 @@ namespace ESMini
         public static extern int SE_OpenOSISocket(string ipaddr);
 
         /// <summary>
+        /// Send OSI packages over UDP to specified IP address, port and with a threshold for
+        /// maximum size for each OSI data package. Value bigger than data_max_size will be split into multiple packages.
+        /// </summary>
+        [DllImport(NativeLibrary, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        public static extern int SE_OpenCustomOSISocket(string ipaddr, uint port, uint data_max_size);
+
+        /// <summary>
         /// Switch off logging to OSI file(s)
         /// </summary>
         /// <returns>0 if successful, -1 if not</returns>

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.cpp
@@ -1706,6 +1706,24 @@ extern "C"
         return returnString.c_str();
     }
 
+    SE_DLL_API int SE_OpenCustomOSISocket(const char *ipaddr, unsigned int port, unsigned int data_max_size)
+    {
+#ifdef _USE_OSI
+        if (player == nullptr)
+        {
+            return -1;
+        }
+
+        player->osiReporter->OpenSocket(ipaddr, port, data_max_size);
+#else
+        (void)ipaddr;
+        (void)port;
+        (void)data_max_size;
+#endif  // _USE_OSI
+
+        return 0;
+    }
+
     SE_DLL_API int SE_OpenOSISocket(const char *ipaddr)
     {
 #ifdef _USE_OSI

--- a/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
+++ b/EnvironmentSimulator/Libraries/esminiLib/esminiLib.hpp
@@ -1577,6 +1577,12 @@ extern "C"
     SE_DLL_API int SE_OpenOSISocket(const char *ipaddr);
 
     /**
+            Send OSI packages over UDP to specified IP address, port and with a threshold for
+            maximum size for each OSI data package. Value bigger than data_max_size will be split into multiple packages.
+    */
+    SE_DLL_API int SE_OpenCustomOSISocket(const char *ipaddr, unsigned int port, unsigned int data_max_size);
+
+    /**
             Switch off logging to OSI file(s)
             @return 0 if successful, -1 if not
     */

--- a/EnvironmentSimulator/Modules/CommonMini/EnumConfig.hpp
+++ b/EnvironmentSimulator/Modules/CommonMini/EnumConfig.hpp
@@ -119,7 +119,7 @@ namespace esmini_options
         OPTIMIZE_3D_MODEL,               // 107
         DISABLE_SHADOWS,                 // 108
         OSI_RECEIVER_PORT,               // 109
-        OSI_RECEIVER_UDP_PACKET_SIZE,    // 110
+        OSI_RECEIVER_UDP_DATA_SIZE,      // 110
         CONFIGS_COUNT                    // this must be the last enum value
     };
 
@@ -234,7 +234,7 @@ namespace esmini_options
         {"optimize_3d_model", OPTIMIZE_3D_MODEL},
         {"disable_shadows", DISABLE_SHADOWS},
         {"osi_receiver_port", OSI_RECEIVER_PORT},
-        {"osi_receiver_udp_data_size", OSI_RECEIVER_UDP_PACKET_SIZE},
+        {"osi_receiver_udp_data_size", OSI_RECEIVER_UDP_DATA_SIZE},
     };
 
     CONFIG_ENUM ConvertStrKeyToEnum(const std::string& key);

--- a/EnvironmentSimulator/Modules/CommonMini/EnumConfig.hpp
+++ b/EnvironmentSimulator/Modules/CommonMini/EnumConfig.hpp
@@ -118,6 +118,8 @@ namespace esmini_options
         SAVE_GENERATED_MODEL_VISIBLE,    // 106
         OPTIMIZE_3D_MODEL,               // 107
         DISABLE_SHADOWS,                 // 108
+        OSI_RECEIVER_PORT,               // 109
+        OSI_RECEIVER_UDP_PACKET_SIZE,    // 110
         CONFIGS_COUNT                    // this must be the last enum value
     };
 
@@ -231,6 +233,8 @@ namespace esmini_options
         {"gui", GUI},
         {"optimize_3d_model", OPTIMIZE_3D_MODEL},
         {"disable_shadows", DISABLE_SHADOWS},
+        {"osi_receiver_port", OSI_RECEIVER_PORT},
+        {"osi_receiver_udp_data_size", OSI_RECEIVER_UDP_PACKET_SIZE},
     };
 
     CONFIG_ENUM ConvertStrKeyToEnum(const std::string& key);

--- a/EnvironmentSimulator/Modules/CommonMini/UDP.cpp
+++ b/EnvironmentSimulator/Modules/CommonMini/UDP.cpp
@@ -170,7 +170,7 @@ unsigned int UDPClient::GetMaxUDPDatagramSize()
     // C++17 Trick (available for Mac Builds), lambda directly called on static to avoid
     // recalling sysctlbyname every time we need to send something over UDP.
     // We are caching it the return value in a static, initialized once per C++17 standard.
-    static const unsigned int max_dgram = []
+    static const unsigned int max_dgram = []() -> unsigned int
     {
         size_t len = sizeof(int);
         int    max_dgram_;

--- a/EnvironmentSimulator/Modules/CommonMini/UDP.cpp
+++ b/EnvironmentSimulator/Modules/CommonMini/UDP.cpp
@@ -11,6 +11,8 @@
  */
 
 #include <stdio.h>
+#include <errno.h>
+#include <limits.h>
 
 #ifndef _WIN32
 #include <sys/time.h>
@@ -19,6 +21,14 @@
 #include "UDP.hpp"
 #include "CommonMini.hpp"
 #include "logger.hpp"
+
+#if defined(__APPLE__)
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <netinet/in.h>
+#include <netinet/udp.h>
+#include <netinet/udp_var.h>
+#endif
 
 UDPBase::UDPBase(unsigned short int port) : port_(port), sock_(SE_INVALID_SOCKET)
 {
@@ -134,8 +144,44 @@ UDPClient::UDPClient(unsigned short int port, std::string ipAddress) : UDPBase(p
 
 int UDPClient::Send(char* buf, unsigned int size)
 {
-    // TODO:
-    // Casting to int can cause overflow in this situation. Not a good idea.
-    // Let's fix it in a way that we actually return size_t and design the flow like that
-    return static_cast<int>(sendto(sock_, buf, size, 0, reinterpret_cast<struct sockaddr*>(&server_addr_), sizeof(server_addr_)));
+    if (size > GetMaxUDPDatagramSize())
+    {
+        LOG_ERROR("Attempting to send UDP datagram of size {} which exceeds system maximum datagram size {}", size, GetMaxUDPDatagramSize());
+        return -1;
+    }
+    // Here, auto handles different signatures of sendto
+    const auto sent_bytes = sendto(sock_, buf, size, 0, reinterpret_cast<struct sockaddr*>(&server_addr_), sizeof(server_addr_));
+    if (sent_bytes < 0)
+    {
+#ifdef _WIN32
+        LOG_ERROR("sendto failed with WinSOCK error number: {}", WSAGetLastError());
+#else
+        LOG_ERROR("sendto failed with error: {}", strerror(errno));
+#endif
+        return -1;
+    }
+    return static_cast<int>(sent_bytes);
+}
+
+unsigned int UDPClient::GetMaxUDPDatagramSize()
+{
+#if defined(__APPLE__)
+    // NOTE:
+    // C++17 Trick (available for Mac Builds), lambda directly called on static to avoid 
+    // recalling sysctlbyname every time we need to send something over UDP. 
+    // We are caching it the return value in a static, initialized once per C++17 standard.
+    static const unsigned int max_dgram = []
+    {
+        size_t len = sizeof(int);
+        int    max_dgram_;
+        if (sysctlbyname("net.inet.udp.maxdgram", &max_dgram_, &len, nullptr, 0) == 0)
+        {
+            return static_cast<unsigned int>(max_dgram_);
+        }
+        return 9216;  // Default value fallback
+    }();
+    return max_dgram;
+#else
+    return 65507;  // Default value for Windows and Linux
+#endif
 }

--- a/EnvironmentSimulator/Modules/CommonMini/UDP.cpp
+++ b/EnvironmentSimulator/Modules/CommonMini/UDP.cpp
@@ -167,8 +167,8 @@ unsigned int UDPClient::GetMaxUDPDatagramSize()
 {
 #if defined(__APPLE__)
     // NOTE:
-    // C++17 Trick (available for Mac Builds), lambda directly called on static to avoid 
-    // recalling sysctlbyname every time we need to send something over UDP. 
+    // C++17 Trick (available for Mac Builds), lambda directly called on static to avoid
+    // recalling sysctlbyname every time we need to send something over UDP.
     // We are caching it the return value in a static, initialized once per C++17 standard.
     static const unsigned int max_dgram = []
     {

--- a/EnvironmentSimulator/Modules/CommonMini/UDP.hpp
+++ b/EnvironmentSimulator/Modules/CommonMini/UDP.hpp
@@ -98,6 +98,13 @@ public:
         return ipAddress_;
     }
 
+    /**
+     * @brief Get the Max UDP Datagram Size for platform
+     *
+     * @return unsigned int maximum size of the datagram
+     */
+    static unsigned int GetMaxUDPDatagramSize();
+
 private:
     std::string ipAddress_;
 };

--- a/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp
+++ b/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp
@@ -1578,9 +1578,9 @@ int ScenarioPlayer::Init()
                   "0");
     opt.AddOption("osi_receiver_ip", "IP address where to send OSI UDP packages", "IP address", "127.0.0.1");
     opt.AddOption("osi_receiver_port", "Port where to send OSI UDP packages (1025 .. 65535)", "port", std::to_string(DEFAULT_OSI_OUT_PORT));
-    opt.AddOption("osi_receiver_udp_data_size", 
-                  "Maximum bytes for OSI data to send as UDP packets, before fragmentation (1024 .. 65499)", 
-                  "size", 
+    opt.AddOption("osi_receiver_udp_data_size",
+                  "Maximum bytes for OSI data to send as UDP packets, before fragmentation (1024 .. 65499)",
+                  "size",
                   std::to_string(DEFAULT_OSI_UDP_DATA_SIZE));
 #endif
     opt.AddOption("param_dist", "Run variations of the scenario according to specified parameter distribution file", "filename");
@@ -1953,9 +1953,9 @@ int ScenarioPlayer::Init()
     odr_manager = scenarioEngine->getRoadManager();
 
 #ifdef _USE_OSI
-    unsigned int osi_port = DEFAULT_OSI_OUT_PORT;
+    unsigned int osi_port            = DEFAULT_OSI_OUT_PORT;
     unsigned int osi_udp_packet_size = DEFAULT_OSI_UDP_DATA_SIZE;
-    
+
     osiReporter = new OSIReporter(scenarioEngine);
     osiReporter->SetCounterPtr(&frame_counter_);
     osiReporter->SetStationaryModelReference(scenarioEngine->getSceneGraphFilename());

--- a/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp
+++ b/EnvironmentSimulator/Modules/PlayerBase/playerbase.cpp
@@ -1572,11 +1572,16 @@ int ScenarioPlayer::Init()
     opt.AddOption("osi_freq", "Decrease OSI file entries, e.g. --osi_freq 2 -> OSI written every two simulation steps", "frequency");
     opt.AddOption("osi_lines", "Show OSI road lines. Toggle key 'u'");
     opt.AddOption("osi_points", "Show OSI road points. Toggle key 'y'");
-    opt.AddOption("osi_receiver_ip", "IP address where to send OSI UDP packages", "IP address", "127.0.0.1");
     opt.AddOption("osi_static_reporting",
                   "Decide how the static data should be reported, 0=Default (first frame), 1=API (expose on API) 2=API_AND_LOG (Always log)",
                   "mode",
                   "0");
+    opt.AddOption("osi_receiver_ip", "IP address where to send OSI UDP packages", "IP address", "127.0.0.1");
+    opt.AddOption("osi_receiver_port", "Port where to send OSI UDP packages (1025 .. 65535)", "port", std::to_string(DEFAULT_OSI_OUT_PORT));
+    opt.AddOption("osi_receiver_udp_data_size", 
+                  "Maximum bytes for OSI data to send as UDP packets, before fragmentation (1024 .. 65499)", 
+                  "size", 
+                  std::to_string(DEFAULT_OSI_UDP_DATA_SIZE));
 #endif
     opt.AddOption("param_dist", "Run variations of the scenario according to specified parameter distribution file", "filename");
     opt.AddOption("param_permutation", "Run specific permutation of parameter distribution, index in range (0 .. NumberOfPermutations-1)", "index");
@@ -1948,14 +1953,28 @@ int ScenarioPlayer::Init()
     odr_manager = scenarioEngine->getRoadManager();
 
 #ifdef _USE_OSI
+    unsigned int osi_port = DEFAULT_OSI_OUT_PORT;
+    unsigned int osi_udp_packet_size = DEFAULT_OSI_UDP_DATA_SIZE;
+    
     osiReporter = new OSIReporter(scenarioEngine);
     osiReporter->SetCounterPtr(&frame_counter_);
     osiReporter->SetStationaryModelReference(scenarioEngine->getSceneGraphFilename());
     scenarioEngine->storyBoard.SetOSIReporter(osiReporter);
 
+    if (opt.GetOptionSet("osi_receiver_port"))
+    {
+        // Note: Validation performed in osiReporter->OpenSocket()
+        osi_port = static_cast<unsigned int>(strtoi(opt.GetOptionValue("osi_receiver_port")));
+    }
+    if (opt.GetOptionSet("osi_receiver_udp_data_size"))
+    {
+        // Note: Validation performed in osiReporter->OpenSocket()
+        osi_udp_packet_size = static_cast<unsigned int>(strtoi(opt.GetOptionValue("osi_receiver_udp_data_size")));
+    }
+
     if (opt.GetOptionSet("osi_receiver_ip"))
     {
-        osiReporter->OpenSocket(opt.GetOptionValue("osi_receiver_ip"));
+        osiReporter->OpenSocket(opt.GetOptionValue("osi_receiver_ip"), osi_port, osi_udp_packet_size);
         if (osiReporter->GetOSIFrequency() == 0)
         {
             osiReporter->SetOSIFrequency(1);

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
@@ -1899,19 +1899,19 @@ int OSIReporter::UpdateOSIIntersection()
                                                 ->GetLaneRoadMarkTypeByIdx(0)
                                                 ->GetLaneRoadMarkTypeLineByIdx(0)
                                                 ->GetOSIPoints();
-                                length    = connecting_road->GetLaneSectionByS(0, 0)
-                                                ->GetLaneById(-l_id)
-                                                ->GetLaneRoadMarkByIdx(0)
-                                                ->GetLaneRoadMarkTypeByIdx(0)
-                                                ->GetLaneRoadMarkTypeLineByIdx(0)
-                                                ->GetOSIPoints()
-                                                ->GetLength();
-                                g_id      = connecting_road->GetLaneSectionByS(0, 0)
-                                                ->GetLaneById(-l_id)
-                                                ->GetLaneRoadMarkByIdx(0)
-                                                ->GetLaneRoadMarkTypeByIdx(0)
-                                                ->GetLaneRoadMarkTypeLineByIdx(0)
-                                                ->GetGlobalId();
+                                length = connecting_road->GetLaneSectionByS(0, 0)
+                                             ->GetLaneById(-l_id)
+                                             ->GetLaneRoadMarkByIdx(0)
+                                             ->GetLaneRoadMarkTypeByIdx(0)
+                                             ->GetLaneRoadMarkTypeLineByIdx(0)
+                                             ->GetOSIPoints()
+                                             ->GetLength();
+                                g_id = connecting_road->GetLaneSectionByS(0, 0)
+                                           ->GetLaneById(-l_id)
+                                           ->GetLaneRoadMarkByIdx(0)
+                                           ->GetLaneRoadMarkTypeByIdx(0)
+                                           ->GetLaneRoadMarkTypeLineByIdx(0)
+                                           ->GetGlobalId();
                             }
                             if ((right_lane_struct.length > length) || (fabs(right_lane_struct.length - length) < tolerance))
                             {
@@ -1939,19 +1939,19 @@ int OSIReporter::UpdateOSIIntersection()
                                                 ->GetLaneRoadMarkTypeByIdx(0)
                                                 ->GetLaneRoadMarkTypeLineByIdx(0)
                                                 ->GetOSIPoints();
-                                length    = connecting_road->GetLaneSectionByS(0, 0)
-                                                ->GetLaneById(l_id)
-                                                ->GetLaneRoadMarkByIdx(0)
-                                                ->GetLaneRoadMarkTypeByIdx(0)
-                                                ->GetLaneRoadMarkTypeLineByIdx(0)
-                                                ->GetOSIPoints()
-                                                ->GetLength();
-                                g_id      = connecting_road->GetLaneSectionByS(0, 0)
-                                                ->GetLaneById(l_id)
-                                                ->GetLaneRoadMarkByIdx(0)
-                                                ->GetLaneRoadMarkTypeByIdx(0)
-                                                ->GetLaneRoadMarkTypeLineByIdx(0)
-                                                ->GetGlobalId();
+                                length = connecting_road->GetLaneSectionByS(0, 0)
+                                             ->GetLaneById(l_id)
+                                             ->GetLaneRoadMarkByIdx(0)
+                                             ->GetLaneRoadMarkTypeByIdx(0)
+                                             ->GetLaneRoadMarkTypeLineByIdx(0)
+                                             ->GetOSIPoints()
+                                             ->GetLength();
+                                g_id = connecting_road->GetLaneSectionByS(0, 0)
+                                           ->GetLaneById(l_id)
+                                           ->GetLaneRoadMarkByIdx(0)
+                                           ->GetLaneRoadMarkTypeByIdx(0)
+                                           ->GetLaneRoadMarkTypeLineByIdx(0)
+                                           ->GetGlobalId();
                             }
                             if ((left_lane_struct.length > length) || (fabs(right_lane_struct.length - length) < tolerance))
                             {

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
@@ -186,7 +186,7 @@ OSIReporter::~OSIReporter()
 
 SE_SOCKET OSIReporter::OpenSocket(std::string ipaddr)
 {
-    udp_client_    = new UDPClient(DEFAULT_OSI_OUT_PORT, ipaddr);
+    udp_client_    = new UDPClient((unsigned short)(DEFAULT_OSI_OUT_PORT), ipaddr);
     udp_data_size_ = DEFAULT_OSI_UDP_DATA_SIZE;
 
     return udp_client_->GetStatus();
@@ -213,7 +213,7 @@ SE_SOCKET OSIReporter::OpenSocket(std::string ipaddr, unsigned int port, unsigne
                  DEFAULT_OSI_OUT_PORT);
         port = DEFAULT_OSI_OUT_PORT;
     }
-    udp_client_    = new UDPClient(port, ipaddr);
+    udp_client_    = new UDPClient((unsigned short)port, ipaddr);
     udp_data_size_ = max_data_size;
 
     return udp_client_->GetStatus();

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
@@ -29,19 +29,19 @@
 #include <unistd.h> /* Needed for close() */
 #endif
 
-#define OSI_OUT_PORT          48198
-#define OSI_MAX_UDP_DATA_SIZE 8192
-
 constexpr const char *SOURCE_REF_TYPE_ODR = "net.asam.opendrive";
 constexpr const char *SOURCE_REF_TYPE_OSC = "net.asam.openscenario";
 
 // Large OSI messages needs to be split for UDP transmission
-// This struct must be mached on receiver side
+// This struct must be matched on receiver side.
+// If struct schema changes, value of MAXIMUM_OSI_UDP_DATA_SIZE must be updated accordingly.
+// On schema changes, consider struct alignment for calculations, or convert the struct
+// to a packed struct.
 static struct
 {
     int          counter;
     unsigned int datasize;
-    char         data[OSI_MAX_UDP_DATA_SIZE];
+    char         data[MAXIMUM_OSI_UDP_DATA_SIZE];
 } osi_udp_buf;
 
 typedef struct
@@ -186,7 +186,31 @@ OSIReporter::~OSIReporter()
 
 SE_SOCKET OSIReporter::OpenSocket(std::string ipaddr)
 {
-    udp_client_ = new UDPClient(OSI_OUT_PORT, ipaddr);
+    udp_client_ = new UDPClient(DEFAULT_OSI_OUT_PORT, ipaddr);
+    udp_data_size_ = DEFAULT_OSI_UDP_DATA_SIZE;
+    
+    return udp_client_->GetStatus();
+}
+
+SE_SOCKET OSIReporter::OpenSocket(std::string ipaddr, unsigned int port, unsigned int max_data_size)
+{
+    if (max_data_size > MAXIMUM_OSI_UDP_DATA_SIZE)
+    {
+        LOG_WARN("Requested OSI UDP data size {} exceeds maximum allowed size {}, using maximum instead", max_data_size, MAXIMUM_OSI_UDP_DATA_SIZE);
+        max_data_size = MAXIMUM_OSI_UDP_DATA_SIZE;
+    }
+    if (max_data_size < MINIMUM_OSI_UDP_DATA_SIZE)
+    {
+        LOG_WARN("Requested OSI UDP data size {} is below minimum allowed size {}, using minimum instead", max_data_size, MINIMUM_OSI_UDP_DATA_SIZE);
+        max_data_size = MINIMUM_OSI_UDP_DATA_SIZE;
+    }
+    if (port < MINIMUM_OSI_OUT_PORT || port > MAXIMUM_OSI_OUT_PORT)
+    {
+        LOG_WARN("Requested OSI UDP port {} is outside allowed range [{}, {}], using default port {}", port, MINIMUM_OSI_OUT_PORT, MAXIMUM_OSI_OUT_PORT, DEFAULT_OSI_OUT_PORT);
+        port = DEFAULT_OSI_OUT_PORT;
+    }
+    udp_client_ = new UDPClient(port, ipaddr);
+    udp_data_size_ = max_data_size;
 
     return udp_client_->GetStatus();
 }
@@ -385,7 +409,7 @@ int OSIReporter::UpdateOSIGroundTruth(const std::vector<scenarioengine::Object *
 
                 obj_osi_external.gt->MergeFrom(*obj_osi_internal.static_gt);  // Merge for API
                 break;
-            case OSIStaticReportMode::API_AND_LOG:  // Log combined ground truth, serialze and transmit combined ground truth
+            case OSIStaticReportMode::API_AND_LOG:  // Log combined ground truth, serialize and transmit combined ground truth
                 if (IsFileOpen() || GetUDPClientStatus() == 0)
                 {
                     SerializeDynamicAndStaticData();
@@ -408,9 +432,9 @@ int OSIReporter::UpdateOSIGroundTruth(const std::vector<scenarioengine::Object *
 
         for (osi_udp_buf.counter = 1; sentDataBytes < osiGroundTruth.size; osi_udp_buf.counter++)
         {
-            osi_udp_buf.datasize = MIN(osiGroundTruth.size - sentDataBytes, OSI_MAX_UDP_DATA_SIZE);
+            osi_udp_buf.datasize = MIN(osiGroundTruth.size - sentDataBytes, udp_data_size_);
             memcpy(osi_udp_buf.data, &osiGroundTruth.ground_truth.c_str()[sentDataBytes], osi_udp_buf.datasize);
-            int packSize = static_cast<int>(sizeof(osi_udp_buf)) - static_cast<int>((OSI_MAX_UDP_DATA_SIZE - osi_udp_buf.datasize));
+            int packSize = static_cast<int>(sizeof(osi_udp_buf)) - static_cast<int>((udp_data_size_ - osi_udp_buf.datasize));
 
             if (sentDataBytes + osi_udp_buf.datasize >= osiGroundTruth.size)
             {

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
@@ -186,9 +186,9 @@ OSIReporter::~OSIReporter()
 
 SE_SOCKET OSIReporter::OpenSocket(std::string ipaddr)
 {
-    udp_client_ = new UDPClient(DEFAULT_OSI_OUT_PORT, ipaddr);
+    udp_client_    = new UDPClient(DEFAULT_OSI_OUT_PORT, ipaddr);
     udp_data_size_ = DEFAULT_OSI_UDP_DATA_SIZE;
-    
+
     return udp_client_->GetStatus();
 }
 
@@ -206,10 +206,14 @@ SE_SOCKET OSIReporter::OpenSocket(std::string ipaddr, unsigned int port, unsigne
     }
     if (port < MINIMUM_OSI_OUT_PORT || port > MAXIMUM_OSI_OUT_PORT)
     {
-        LOG_WARN("Requested OSI UDP port {} is outside allowed range [{}, {}], using default port {}", port, MINIMUM_OSI_OUT_PORT, MAXIMUM_OSI_OUT_PORT, DEFAULT_OSI_OUT_PORT);
+        LOG_WARN("Requested OSI UDP port {} is outside allowed range [{}, {}], using default port {}",
+                 port,
+                 MINIMUM_OSI_OUT_PORT,
+                 MAXIMUM_OSI_OUT_PORT,
+                 DEFAULT_OSI_OUT_PORT);
         port = DEFAULT_OSI_OUT_PORT;
     }
-    udp_client_ = new UDPClient(port, ipaddr);
+    udp_client_    = new UDPClient(port, ipaddr);
     udp_data_size_ = max_data_size;
 
     return udp_client_->GetStatus();
@@ -1895,19 +1899,19 @@ int OSIReporter::UpdateOSIIntersection()
                                                 ->GetLaneRoadMarkTypeByIdx(0)
                                                 ->GetLaneRoadMarkTypeLineByIdx(0)
                                                 ->GetOSIPoints();
-                                length = connecting_road->GetLaneSectionByS(0, 0)
-                                             ->GetLaneById(-l_id)
-                                             ->GetLaneRoadMarkByIdx(0)
-                                             ->GetLaneRoadMarkTypeByIdx(0)
-                                             ->GetLaneRoadMarkTypeLineByIdx(0)
-                                             ->GetOSIPoints()
-                                             ->GetLength();
-                                g_id = connecting_road->GetLaneSectionByS(0, 0)
-                                           ->GetLaneById(-l_id)
-                                           ->GetLaneRoadMarkByIdx(0)
-                                           ->GetLaneRoadMarkTypeByIdx(0)
-                                           ->GetLaneRoadMarkTypeLineByIdx(0)
-                                           ->GetGlobalId();
+                                length    = connecting_road->GetLaneSectionByS(0, 0)
+                                                ->GetLaneById(-l_id)
+                                                ->GetLaneRoadMarkByIdx(0)
+                                                ->GetLaneRoadMarkTypeByIdx(0)
+                                                ->GetLaneRoadMarkTypeLineByIdx(0)
+                                                ->GetOSIPoints()
+                                                ->GetLength();
+                                g_id      = connecting_road->GetLaneSectionByS(0, 0)
+                                                ->GetLaneById(-l_id)
+                                                ->GetLaneRoadMarkByIdx(0)
+                                                ->GetLaneRoadMarkTypeByIdx(0)
+                                                ->GetLaneRoadMarkTypeLineByIdx(0)
+                                                ->GetGlobalId();
                             }
                             if ((right_lane_struct.length > length) || (fabs(right_lane_struct.length - length) < tolerance))
                             {
@@ -1935,19 +1939,19 @@ int OSIReporter::UpdateOSIIntersection()
                                                 ->GetLaneRoadMarkTypeByIdx(0)
                                                 ->GetLaneRoadMarkTypeLineByIdx(0)
                                                 ->GetOSIPoints();
-                                length = connecting_road->GetLaneSectionByS(0, 0)
-                                             ->GetLaneById(l_id)
-                                             ->GetLaneRoadMarkByIdx(0)
-                                             ->GetLaneRoadMarkTypeByIdx(0)
-                                             ->GetLaneRoadMarkTypeLineByIdx(0)
-                                             ->GetOSIPoints()
-                                             ->GetLength();
-                                g_id = connecting_road->GetLaneSectionByS(0, 0)
-                                           ->GetLaneById(l_id)
-                                           ->GetLaneRoadMarkByIdx(0)
-                                           ->GetLaneRoadMarkTypeByIdx(0)
-                                           ->GetLaneRoadMarkTypeLineByIdx(0)
-                                           ->GetGlobalId();
+                                length    = connecting_road->GetLaneSectionByS(0, 0)
+                                                ->GetLaneById(l_id)
+                                                ->GetLaneRoadMarkByIdx(0)
+                                                ->GetLaneRoadMarkTypeByIdx(0)
+                                                ->GetLaneRoadMarkTypeLineByIdx(0)
+                                                ->GetOSIPoints()
+                                                ->GetLength();
+                                g_id      = connecting_road->GetLaneSectionByS(0, 0)
+                                                ->GetLaneById(l_id)
+                                                ->GetLaneRoadMarkByIdx(0)
+                                                ->GetLaneRoadMarkTypeByIdx(0)
+                                                ->GetLaneRoadMarkTypeLineByIdx(0)
+                                                ->GetGlobalId();
                             }
                             if ((left_lane_struct.length > length) || (fabs(right_lane_struct.length - length) < tolerance))
                             {

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
@@ -455,7 +455,7 @@ int OSIReporter::UpdateOSIGroundTruth(const std::vector<scenarioengine::Object *
             if (sendResult != packSize)
             {
                 LOG_ERROR("Failed send osi package over UDP");
-                sentDataBytes = osiGroundTruth.size; // Giving up on sending the rest of the data
+                sentDataBytes = osiGroundTruth.size;  // Giving up on sending the rest of the data
             }
             else
             {

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
@@ -44,6 +44,8 @@ static struct
     char         data[MAXIMUM_OSI_UDP_DATA_SIZE];
 } osi_udp_buf;
 
+constexpr unsigned int osi_udp_buf_header_size = static_cast<unsigned int>(sizeof(osi_udp_buf.counter) + sizeof(osi_udp_buf.datasize));
+
 typedef struct
 {
     std::string  ground_truth;
@@ -194,10 +196,12 @@ SE_SOCKET OSIReporter::OpenSocket(std::string ipaddr)
 
 SE_SOCKET OSIReporter::OpenSocket(std::string ipaddr, unsigned int port, unsigned int max_data_size)
 {
-    if (max_data_size > MAXIMUM_OSI_UDP_DATA_SIZE)
+    // Checks maximum datagram lenght, according to platform (i.e., commonly 65507, normally 9216 for Darwin)
+    const unsigned int platform_max_udp_data_size = UDPClient::GetMaxUDPDatagramSize() - osi_udp_buf_header_size;
+    if (max_data_size > platform_max_udp_data_size)
     {
-        LOG_WARN("Requested OSI UDP data size {} exceeds maximum allowed size {}, using maximum instead", max_data_size, MAXIMUM_OSI_UDP_DATA_SIZE);
-        max_data_size = MAXIMUM_OSI_UDP_DATA_SIZE;
+        LOG_WARN("Requested OSI UDP data size {} exceeds maximum allowed size {}, using maximum instead", max_data_size, platform_max_udp_data_size);
+        max_data_size = platform_max_udp_data_size;
     }
     if (max_data_size < MINIMUM_OSI_UDP_DATA_SIZE)
     {
@@ -438,7 +442,7 @@ int OSIReporter::UpdateOSIGroundTruth(const std::vector<scenarioengine::Object *
         {
             osi_udp_buf.datasize = MIN(osiGroundTruth.size - sentDataBytes, udp_data_size_);
             memcpy(osi_udp_buf.data, &osiGroundTruth.ground_truth.c_str()[sentDataBytes], osi_udp_buf.datasize);
-            int packSize = static_cast<int>(sizeof(osi_udp_buf)) - static_cast<int>((udp_data_size_ - osi_udp_buf.datasize));
+            const int packSize = static_cast<int>(osi_udp_buf_header_size + osi_udp_buf.datasize);
 
             if (sentDataBytes + osi_udp_buf.datasize >= osiGroundTruth.size)
             {
@@ -446,16 +450,12 @@ int OSIReporter::UpdateOSIGroundTruth(const std::vector<scenarioengine::Object *
                 osi_udp_buf.counter = -osi_udp_buf.counter;
             }
 
-            int sendResult = udp_client_->Send(reinterpret_cast<char *>(&osi_udp_buf), static_cast<unsigned int>(packSize));  // TODO: @Emil
+            int sendResult = udp_client_->Send(reinterpret_cast<char *>(&osi_udp_buf), static_cast<unsigned int>(packSize));
 
             if (sendResult != packSize)
             {
                 LOG_ERROR("Failed send osi package over UDP");
-#ifdef _WIN32
-                wprintf(L"send failed with error: %d\n", WSAGetLastError());
-#endif
-                // Give up
-                sentDataBytes = osiGroundTruth.size;
+                sentDataBytes = osiGroundTruth.size; // Giving up on sending the rest of the data
             }
             else
             {

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp
@@ -186,7 +186,7 @@ OSIReporter::~OSIReporter()
 
 SE_SOCKET OSIReporter::OpenSocket(std::string ipaddr)
 {
-    udp_client_    = new UDPClient((unsigned short)(DEFAULT_OSI_OUT_PORT), ipaddr);
+    udp_client_    = new UDPClient(static_cast<unsigned short>(DEFAULT_OSI_OUT_PORT), ipaddr);
     udp_data_size_ = DEFAULT_OSI_UDP_DATA_SIZE;
 
     return udp_client_->GetStatus();
@@ -213,7 +213,7 @@ SE_SOCKET OSIReporter::OpenSocket(std::string ipaddr, unsigned int port, unsigne
                  DEFAULT_OSI_OUT_PORT);
         port = DEFAULT_OSI_OUT_PORT;
     }
-    udp_client_    = new UDPClient((unsigned short)port, ipaddr);
+    udp_client_    = new UDPClient(static_cast<unsigned short>(port), ipaddr);
     udp_data_size_ = max_data_size;
 
     return udp_client_->GetStatus();

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.hpp
@@ -40,11 +40,10 @@
 #define MAXIMUM_OSI_OUT_PORT 65536
 
 #define DEFAULT_OSI_UDP_DATA_SIZE 8192
-// Note: maximum size is datagram payload size (65507) minus 4 bytes for counter and 4 bytes for datasize
-//       If UDP packet schema changes, this value must be updated accordingly.
-#define MAXIMUM_OSI_UDP_DATA_SIZE (65507 - sizeof(int) - sizeof(unsigned int))
+// Note: maximum size is datagram payload size (65507)
+#define MAXIMUM_OSI_UDP_DATA_SIZE 65507
 // Note: minimum size is less than common MTU (1500). It makes no sense to set it lower.
-#define MINIMUM_OSI_UDP_DATA_SIZE (1472 - sizeof(int) - sizeof(unsigned int))
+#define MINIMUM_OSI_UDP_DATA_SIZE 1400
 
 using namespace scenarioengine;
 

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.hpp
@@ -33,7 +33,7 @@
 #include <map>
 #include <math.h>
 
-#define DEFAULT_OSI_TRACE_FILENAME  "ground_truth.osi"
+#define DEFAULT_OSI_TRACE_FILENAME "ground_truth.osi"
 
 #define DEFAULT_OSI_OUT_PORT 48198
 #define MINIMUM_OSI_OUT_PORT 1024

--- a/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.hpp
+++ b/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.hpp
@@ -33,7 +33,18 @@
 #include <map>
 #include <math.h>
 
-#define DEFAULT_OSI_TRACE_FILENAME "ground_truth.osi"
+#define DEFAULT_OSI_TRACE_FILENAME  "ground_truth.osi"
+
+#define DEFAULT_OSI_OUT_PORT 48198
+#define MINIMUM_OSI_OUT_PORT 1024
+#define MAXIMUM_OSI_OUT_PORT 65536
+
+#define DEFAULT_OSI_UDP_DATA_SIZE 8192
+// Note: maximum size is datagram payload size (65507) minus 4 bytes for counter and 4 bytes for datasize
+//       If UDP packet schema changes, this value must be updated accordingly.
+#define MAXIMUM_OSI_UDP_DATA_SIZE (65507 - sizeof(int) - sizeof(unsigned int))
+// Note: minimum size is less than common MTU (1500). It makes no sense to set it lower.
+#define MINIMUM_OSI_UDP_DATA_SIZE (1472 - sizeof(int) - sizeof(unsigned int))
 
 using namespace scenarioengine;
 
@@ -217,6 +228,7 @@ public:
     idx_t             GetLaneIdxfromIdOSI(id_t lane_id);
     osi3::Lane*       GetOSILaneFromGlobalId(id_t g_id);
     SE_SOCKET         OpenSocket(std::string ipaddr);
+    SE_SOCKET         OpenSocket(std::string ipaddr, unsigned int port, unsigned int max_data_size);
     void              SerializeDynamicData();
     void              SerializeDynamicAndStaticData();
     void              AddTrafficLightToGt(osi3::GroundTruth* gt, roadmanager::Signal* signal);
@@ -284,6 +296,7 @@ public:
 
 private:
     UDPClient*                                      udp_client_;
+    unsigned int                                    udp_data_size_ = DEFAULT_OSI_UDP_DATA_SIZE;
     ScenarioEngine*                                 scenario_engine_;
     std::ofstream                                   osi_file;
     int*                                            osi_update_counter_ = nullptr;

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -148,6 +148,12 @@ if [[ "$skip_smoke_test" == false ]]; then
     if ! ${PYTHON} ncap_suite.py -t $timeout; then
         exit_with_msg "ncap_suite test failed"
     fi
+
+    echo $'\n'Run OSI UDP test suite:
+
+    if ! ${PYTHON} osi_udp_test.py -t $timeout; then
+        exit_with_msg "osi_udp_test failed"
+    fi
 fi
 
 if  [[ "$add_performance_test" == true ]] && [[ "$build_type" == "Release" ]]; then

--- a/test/osi_udp_test.py
+++ b/test/osi_udp_test.py
@@ -1,0 +1,223 @@
+import os
+import re
+import socket
+import struct
+import sys
+import threading
+import time
+import unittest
+import argparse
+
+from test_common import ESMINI_PATH, set_timeout, run_scenario
+
+SCENARIO_PATH = os.path.join(ESMINI_PATH, 'resources/xosc/cut-in.xosc')
+COMMON_ARGS = '--headless --fixed_timestep 0.05 --quit_at_end '
+
+
+def is_osi_supported():
+    return os.path.isfile(os.path.join(ESMINI_PATH, 'bin', 'osireceiver')) or \
+           os.path.isfile(os.path.join(ESMINI_PATH, 'bin', 'osireceiver.exe'))
+
+
+class UdpPacketCollector:
+    def __init__(self, ip='127.0.0.1', port=48198, timeout=5.0, max_packets=10):
+        self.ip = ip
+        self.port = port
+        self.timeout = timeout
+        self.max_packets = max_packets
+        self.packets = []
+        self.sock = None
+        self.thread = None
+        self.started_event = threading.Event()
+        self.stop_event = threading.Event()
+
+    def _listen(self):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind((self.ip, self.port))
+        self.sock.settimeout(0.2)
+        self.started_event.set()
+
+        start_time = time.time()
+        while not self.stop_event.is_set() and (time.time() - start_time < self.timeout):
+            if len(self.packets) >= self.max_packets:
+                break
+            try:
+                data, _ = self.sock.recvfrom(65536)
+                self.packets.append(data)
+            except socket.timeout:
+                continue
+            except Exception:
+                break
+
+    def start(self):
+        self.thread = threading.Thread(target=self._listen)
+        self.thread.daemon = True
+        self.thread.start()
+        self.started_event.wait(timeout=2.0)
+
+    def stop(self):
+        self.stop_event.set()
+        if self.thread:
+            self.thread.join(timeout=2.0)
+        if self.sock:
+            try:
+                self.sock.close()
+            except Exception:
+                pass
+
+
+class TestSuite(unittest.TestCase):
+
+    def test_osi_udp_custom_port(self):
+        """Test sending OSI packets over a custom UDP port (127.0.0.1:5000)."""
+        if not is_osi_supported():
+            print('skipping test_osi_udp_custom_port for non-OSI builds ', end='', file=sys.stderr)
+            return
+
+        port = 5000
+        collector = UdpPacketCollector(ip='127.0.0.1', port=port, max_packets=5)
+        collector.start()
+
+        try:
+            log, _, _, _ = run_scenario(
+                SCENARIO_PATH,
+                COMMON_ARGS + f'--osi_receiver_ip 127.0.0.1 --osi_receiver_port {port}'
+            )
+        finally:
+            collector.stop()
+
+        self.assertGreater(len(collector.packets), 0, f"No packets received on custom port {port}")
+        counter, datasize = struct.unpack('iI', collector.packets[0][:8])
+        self.assertNotEqual(counter, 0, "Packet counter should not be 0")
+        self.assertGreater(datasize, 0, "Packet datasize should be positive")
+
+    def test_osi_udp_custom_data_size(self):
+        """Test sending OSI packets with custom max UDP data size (1500 bytes)."""
+        if not is_osi_supported():
+            print('skipping test_osi_udp_custom_data_size for non-OSI builds ', end='', file=sys.stderr)
+            return
+
+        port = 5000
+        max_size = 1500
+        collector = UdpPacketCollector(ip='127.0.0.1', port=port, max_packets=10)
+        collector.start()
+
+        try:
+            log, _, _, _ = run_scenario(
+                SCENARIO_PATH,
+                COMMON_ARGS + f'--osi_receiver_ip 127.0.0.1 --osi_receiver_port {port} --osi_receiver_udp_data_size {max_size}'
+            )
+        finally:
+            collector.stop()
+
+        self.assertGreater(len(collector.packets), 0, f"No packets received on port {port}")
+        for idx, packet in enumerate(collector.packets):
+            self.assertGreaterEqual(len(packet), 8, f"Packet {idx} is smaller than 8-byte header")
+            counter, datasize = struct.unpack('iI', packet[:8])
+            self.assertLessEqual(
+                datasize,
+                max_size,
+                f"Packet {idx} datasize ({datasize}) exceeds configured max data size ({max_size})"
+            )
+
+    def test_osi_udp_default_values(self):
+        """Test default UDP port (48198) and default max data size (8192 bytes)."""
+        if not is_osi_supported():
+            print('skipping test_osi_udp_default_values for non-OSI builds ', end='', file=sys.stderr)
+            return
+
+        default_port = 48198
+        default_max_data_size = 8192
+        collector = UdpPacketCollector(ip='127.0.0.1', port=default_port, max_packets=5)
+        collector.start()
+
+        try:
+            log, _, _, _ = run_scenario(
+                SCENARIO_PATH,
+                COMMON_ARGS + '--osi_receiver_ip 127.0.0.1'
+            )
+        finally:
+            collector.stop()
+
+        self.assertGreater(len(collector.packets), 0, f"No packets received on default port {default_port}")
+        for idx, packet in enumerate(collector.packets):
+            self.assertGreaterEqual(len(packet), 8, f"Packet {idx} is smaller than 8-byte header")
+            counter, datasize = struct.unpack('iI', packet[:8])
+            self.assertLessEqual(
+                datasize,
+                default_max_data_size,
+                f"Packet {idx} datasize ({datasize}) exceeds default max data size ({default_max_data_size})"
+            )
+
+    def test_osi_udp_invalid_port_warning(self):
+        """Test warning messages when port is out of allowed range [1024, 65536]."""
+        if not is_osi_supported():
+            print('skipping test_osi_udp_invalid_port_warning for non-OSI builds ', end='', file=sys.stderr)
+            return
+
+        # Low port (< 1024)
+        log_low, _, _, err_low = run_scenario(
+            SCENARIO_PATH,
+            COMMON_ARGS + '--osi_receiver_ip 127.0.0.1 --osi_receiver_port 500'
+        )
+        combined_low = (log_low or '') + (err_low or '')
+        self.assertIsNotNone(
+            re.search(r'Requested OSI UDP port 500 is outside allowed range \[1024, 65536\], using default port 48198', combined_low),
+            f"Expected port warning not found in log for port 500. Output:\n{combined_low}"
+        )
+
+        # High port (> 65536)
+        log_high, _, _, err_high = run_scenario(
+            SCENARIO_PATH,
+            COMMON_ARGS + '--osi_receiver_ip 127.0.0.1 --osi_receiver_port 70000'
+        )
+        combined_high = (log_high or '') + (err_high or '')
+        self.assertIsNotNone(
+            re.search(r'Requested OSI UDP port 70000 is outside allowed range \[1024, 65536\], using default port 48198', combined_high),
+            f"Expected port warning not found in log for port 70000. Output:\n{combined_high}"
+        )
+
+    def test_osi_udp_invalid_data_size_warning(self):
+        """Test warning messages when data size is out of allowed range [1464, 65499]."""
+        if not is_osi_supported():
+            print('skipping test_osi_udp_invalid_data_size_warning for non-OSI builds ', end='', file=sys.stderr)
+            return
+
+        # Size below minimum (< 1464)
+        log_low, _, _, err_low = run_scenario(
+            SCENARIO_PATH,
+            COMMON_ARGS + '--osi_receiver_ip 127.0.0.1 --osi_receiver_udp_data_size 500'
+        )
+        combined_low = (log_low or '') + (err_low or '')
+        self.assertIsNotNone(
+            re.search(r'Requested OSI UDP data size 500 is below minimum allowed size 1464, using minimum instead', combined_low),
+            f"Expected data size warning not found in log for size 500. Output:\n{combined_low}"
+        )
+
+        # Size above maximum (> 65499)
+        log_high, _, _, err_high = run_scenario(
+            SCENARIO_PATH,
+            COMMON_ARGS + '--osi_receiver_ip 127.0.0.1 --osi_receiver_udp_data_size 100000'
+        )
+        combined_high = (log_high or '') + (err_high or '')
+        self.assertIsNotNone(
+            re.search(r'Requested OSI UDP data size 100000 exceeds maximum allowed size 65499, using maximum instead', combined_high),
+            f"Expected data size warning not found in log for size 100000. Output:\n{combined_high}"
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", "--timeout", type=int, default=40, help="timeout per testcase")
+    parser.add_argument("testcase", nargs="?", help="run only this testcase")
+    args = parser.parse_args()
+
+    print("timeout:", args.timeout, file=sys.stderr)
+    set_timeout(args.timeout)
+
+    if args.testcase:
+        unittest.main(argv=['ignored', '-v', 'TestSuite.' + args.testcase])
+    else:
+        unittest.main(argv=[''], verbosity=2)
+

--- a/test/osi_udp_test.py
+++ b/test/osi_udp_test.py
@@ -7,6 +7,7 @@ import threading
 import time
 import unittest
 import argparse
+import subprocess
 
 from test_common import ESMINI_PATH, set_timeout, run_scenario
 
@@ -17,6 +18,17 @@ COMMON_ARGS = '--headless --fixed_timestep 0.05 --quit_at_end '
 def is_osi_supported():
     return os.path.isfile(os.path.join(ESMINI_PATH, 'bin', 'osireceiver')) or \
            os.path.isfile(os.path.join(ESMINI_PATH, 'bin', 'osireceiver.exe'))
+
+
+def get_macos_maxdgram():
+    """Retrieve macOS net.inet.udp.maxdgram via sysctl, fallback to 9216."""
+    if sys.platform == 'darwin':
+        try:
+            out = subprocess.check_output(['sysctl', '-n', 'net.inet.udp.maxdgram'], text=True).strip()
+            return int(out)
+        except Exception:
+            return 9216
+    return 65507  # Standard maximum IPv4 UDP datagram size on Linux/Windows
 
 
 class UdpPacketCollector:
@@ -93,33 +105,53 @@ class TestSuite(unittest.TestCase):
         self.assertGreater(datasize, 0, "Packet datasize should be positive")
 
     def test_osi_udp_custom_data_size(self):
-        """Test sending OSI packets with custom max UDP data size (1500 bytes)."""
+        """Test sending OSI packets with a variety of max UDP data sizes: [1410, 9000, 65500]."""
         if not is_osi_supported():
             print('skipping test_osi_udp_custom_data_size for non-OSI builds ', end='', file=sys.stderr)
             return
 
+        test_sizes = [1410, 9000, 65500]
         port = 5000
-        max_size = 1500
-        collector = UdpPacketCollector(ip='127.0.0.1', port=port, max_packets=10)
-        collector.start()
 
-        try:
-            log, _, _, _ = run_scenario(
-                SCENARIO_PATH,
-                COMMON_ARGS + f'--osi_receiver_ip 127.0.0.1 --osi_receiver_port {port} --osi_receiver_udp_data_size {max_size}'
-            )
-        finally:
-            collector.stop()
+        for max_size in test_sizes:
+            # Skip sizes larger than macOS kernel UDP datagram limit (net.inet.udp.maxdgram)
+            if sys.platform == 'darwin' and (max_size + 8) > get_macos_maxdgram():
+                print(f"skipping size {max_size} on macOS (exceeds maxdgram {get_macos_maxdgram()}) ", end='', file=sys.stderr)
+                continue
 
-        self.assertGreater(len(collector.packets), 0, f"No packets received on port {port}")
-        for idx, packet in enumerate(collector.packets):
-            self.assertGreaterEqual(len(packet), 8, f"Packet {idx} is smaller than 8-byte header")
-            counter, datasize = struct.unpack('iI', packet[:8])
-            self.assertLessEqual(
-                datasize,
-                max_size,
-                f"Packet {idx} datasize ({datasize}) exceeds configured max data size ({max_size})"
-            )
+            with self.subTest(max_size=max_size):
+                collector = UdpPacketCollector(ip='127.0.0.1', port=port, max_packets=10)
+                collector.start()
+
+                try:
+                    log, _, _, _ = run_scenario(
+                        SCENARIO_PATH,
+                        COMMON_ARGS + f'--osi_receiver_ip 127.0.0.1 --osi_receiver_port {port} --osi_receiver_udp_data_size {max_size}'
+                    )
+                finally:
+                    collector.stop()
+
+                self.assertGreater(len(collector.packets), 0, f"No packets received on port {port} for size {max_size}")
+
+                # Note: if size is below minimum (1464), esmini clamps it to 1464
+                effective_max_size = max(max_size, 1464)
+
+                for idx, packet in enumerate(collector.packets):
+                    self.assertGreaterEqual(len(packet), 8, f"Packet {idx} is smaller than 8-byte header")
+                    counter, datasize = struct.unpack('iI', packet[:8])
+
+                    # Verify datasize never exceeds the effective threshold
+                    self.assertLessEqual(
+                        datasize,
+                        effective_max_size,
+                        f"Packet {idx} datasize ({datasize}) exceeds effective max data size ({effective_max_size})"
+                    )
+                    # Verify packet length matches exactly header (8 bytes) + payload (no garbage data)
+                    self.assertEqual(
+                        len(packet),
+                        8 + datasize,
+                        f"Packet {idx} length ({len(packet)}) does not match header + datasize ({8 + datasize})"
+                    )
 
     def test_osi_udp_default_values(self):
         """Test default UDP port (48198) and default max data size (8192 bytes)."""
@@ -149,9 +181,14 @@ class TestSuite(unittest.TestCase):
                 default_max_data_size,
                 f"Packet {idx} datasize ({datasize}) exceeds default max data size ({default_max_data_size})"
             )
+            self.assertEqual(
+                len(packet),
+                8 + datasize,
+                f"Packet {idx} length ({len(packet)}) does not match header + datasize ({8 + datasize})"
+            )
 
     def test_osi_udp_invalid_port_warning(self):
-        """Test warning messages when port is out of allowed range [1024, 65536]."""
+        """Test warning messages when port is out of allowed range"""
         if not is_osi_supported():
             print('skipping test_osi_udp_invalid_port_warning for non-OSI builds ', end='', file=sys.stderr)
             return
@@ -163,7 +200,7 @@ class TestSuite(unittest.TestCase):
         )
         combined_low = (log_low or '') + (err_low or '')
         self.assertIsNotNone(
-            re.search(r'Requested OSI UDP port 500 is outside allowed range \[1024, 65536\], using default port 48198', combined_low),
+            re.search(r'Requested OSI UDP port 500 is outside allowed range \[\d+, \d+\], using default port \d+', combined_low),
             f"Expected port warning not found in log for port 500. Output:\n{combined_low}"
         )
 
@@ -174,12 +211,12 @@ class TestSuite(unittest.TestCase):
         )
         combined_high = (log_high or '') + (err_high or '')
         self.assertIsNotNone(
-            re.search(r'Requested OSI UDP port 70000 is outside allowed range \[1024, 65536\], using default port 48198', combined_high),
+            re.search(r'Requested OSI UDP port 70000 is outside allowed range \[\d+, \d+\], using default port \d+', combined_high),
             f"Expected port warning not found in log for port 70000. Output:\n{combined_high}"
         )
 
     def test_osi_udp_invalid_data_size_warning(self):
-        """Test warning messages when data size is out of allowed range [1464, 65499]."""
+        """Test warning messages when data size is out of allowed range"""
         if not is_osi_supported():
             print('skipping test_osi_udp_invalid_data_size_warning for non-OSI builds ', end='', file=sys.stderr)
             return
@@ -191,18 +228,19 @@ class TestSuite(unittest.TestCase):
         )
         combined_low = (log_low or '') + (err_low or '')
         self.assertIsNotNone(
-            re.search(r'Requested OSI UDP data size 500 is below minimum allowed size 1464, using minimum instead', combined_low),
+            re.search(r'Requested OSI UDP data size \d+ is below minimum allowed size \d+, using minimum instead', combined_low),
             f"Expected data size warning not found in log for size 500. Output:\n{combined_low}"
         )
 
-        # Size above maximum (> 65499)
+        # Size above maximum (> maximum allowed)
         log_high, _, _, err_high = run_scenario(
             SCENARIO_PATH,
             COMMON_ARGS + '--osi_receiver_ip 127.0.0.1 --osi_receiver_udp_data_size 100000'
         )
         combined_high = (log_high or '') + (err_high or '')
+        # Regex matches any maximum allowed size (65499 on Linux/Windows or dynamic max on macOS)
         self.assertIsNotNone(
-            re.search(r'Requested OSI UDP data size 100000 exceeds maximum allowed size 65499, using maximum instead', combined_high),
+            re.search(r'Requested OSI UDP data size \d+ exceeds maximum allowed size \d+, using maximum instead', combined_high),
             f"Expected data size warning not found in log for size 100000. Output:\n{combined_high}"
         )
 
@@ -220,4 +258,3 @@ if __name__ == "__main__":
         unittest.main(argv=['ignored', '-v', 'TestSuite.' + args.testcase])
     else:
         unittest.main(argv=[''], verbosity=2)
-


### PR DESCRIPTION
### Description

This PR adds support for configuring both the UDP port and the maximum UDP data payload size for OSI output transmission in esmini, and introduces a dedicated test suite to validate these options.

Closes #836 

### Changes

- **CLI Options**: Added `--osi_receiver_port <port>` (valid range: 1024..65536, default: 48198) and `--osi_receiver_udp_data_size <size>` (valid range: 1464..65499, default: 8192). Implementation uses same defaults as before.
- **C API**: Exposed `SE_OpenCustomOSISocket(const char *ipaddr, unsigned int port, unsigned int data_max_size)` in `esminiLib` while preserving backwards compatibility with `SE_OpenOSISocket`. **Is the name for the public api ok?**.
- Added bounds checks and warning logs in `OSIReporter` when requested port or data size values fall outside allowable ranges. I hope it is clear enough...
- Updated `osi_receiver.cpp` buffer size to handle packets up to 64 KB.
- **C#**: updated `ESMiniWrapper.cs`

**Am I missing something?**

### Testing

I added new test `test/osi_udp_test.py` (and registered it in `scripts/run_tests.sh`) covering:

1. Verifies UDP transmission on custom port `127.0.0.1:5000`.
2. Verifies that received packets respect the requested data size threshold (e.g., 1500 bytes) and valid 8-byte header layout (`counter`, `datasize`).
3. Verifies default behavior on port 48198 and standard 8192-byte limit when no flags are supplied.
4. Verifies that out-of-range ports trigger appropriate warning logs and fallback to default.
5. Verifies that below-minimum and above-maximum data size inputs trigger clamping warning logs.

I'll leave aside multicast implementation. It mainly impacts `osi_receiver.cpp`, and it needs the implementation of a "configuration" for it. See #836 for more info.

### Additional Notes

- On OSX, maximum datagram size is defined by sysctl `"net.inet.udp.maxdgram"`. This information is collected at runtime to clamp the maximum data size. Tests also consider this.
- There was a TODO note for @eknabe [here](https://github.com/esmini/esmini/blob/dev/EnvironmentSimulator/Modules/ScenarioEngine/SourceFiles/OSIReporter.cpp#L421) regarding a possible overflow. I handled it with input sanitization. Data size cannot be larger than theoretical UDP datagram size (64k and dimes) so it can never overflow.